### PR TITLE
Change dependency on base to <4.8

### DIFF
--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -16,7 +16,7 @@ executable hap
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:         base >=4.6 && <4.7
+  build-depends:         base >=4.6 && <4.8
                        , time
                        , old-locale
                        , process


### PR DESCRIPTION
It seems that the current dependency of >=4.6 && <4.7 doesn't build on
GHC 7.8.2.
