### PR TITLE
Parse env variable PORT

### DIFF
--- a/spec/System/HapistranoSpec.hs
+++ b/spec/System/HapistranoSpec.hs
@@ -115,6 +115,7 @@ defaultState tmpDir testRepo =
              , Hap.revision       = "master"
              , Hap.buildScript    = Nothing
              , Hap.restartCommand = Nothing
+             , Hap.port           = Nothing
              }
 
 -- | The 'fromRight' function extracts the element out of a 'Right' and

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -30,6 +30,9 @@ data Config =
          , restartCommand :: Maybe String
            -- ^ Optional command to restart the server after a successful deploy
 
+         , port :: Maybe Integer
+           -- ^ Optional port to deploy to a different ssh port
+
          } deriving (Show)
 
 data ReleaseFormat = Short


### PR DESCRIPTION
I lookup the environmental variable `PORT` to deploy the application to a different ssh port if it is present. If it is not, then we take the default port. So, the variable `PORT` is optional. To solve #35 
