### PR TITLE
Use a different Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,44 @@
-# This file is based on a generated file.
-# See https://github.com/hvr/multi-ghc-travis.
-
 language: c
 
 sudo: false
 
-# GHC depends on GMP. You can add other dependencies here as well.
-addons:
-  apt:
-    packages:
-    - libgmp-dev
-
-cache:
-  directories:
-    - $HOME/.stack
-
 matrix:
   include:
-  - env: ARGS="--resolver lts-2"
-    compiler: ": # lts-2 gch-7.8.4"
-  - env: ARGS="--resolver lts-3"
-    compiler: ": # lts-3 gch-7.10.2"
-  - env: ARGS="--resolver lts"
-    compiler: ": # lts"
+    - env: CABALVER=1.24 GHCVER=7.6.3
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3],sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=head
+      addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
+
+  allow_failures:
+    - env: CABALVER=head GHCVER=head
 
 before_install:
-# Using compiler above sets CC to an invalid value, so unset it
-- unset CC
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
-# Download and unpack the stack executable
-- mkdir -p ~/.local/bin
-- export PATH=$HOME/.local/bin:$PATH
-- curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests
 
-# This line does all of the work: installs GHC if necessary, build the library,
-# executables, and test suites, and runs the test suites. --no-terminal works
-# around some quirks in Travis's terminal implementation.
-script: stack $ARGS --no-terminal --install-ghc test --haddock --no-haddock-deps
+script:
+ - case "$GHCVER" in
+     "7.6.3") cabal configure --enable-tests -v2 -f dev ;;
+     *)       cabal configure --enable-tests --enable-coverage -v2 -f dev ;;
+   esac
+ - cabal build
+ - case "$GHCVER" in
+     "7.6.3") true ;;
+     *)       cabal test --show-details=always ;;
+   esac
+ - cabal sdist
+ - cabal haddock | grep "100%" | wc -l | grep "2"
+
+notifications:
+  email: false

--- a/app/Command.hs
+++ b/app/Command.hs
@@ -1,5 +1,6 @@
 module Command where
 
+import Data.Monoid ((<>))
 import Options.Applicative
 
 data Command
@@ -18,4 +19,3 @@ commands
     addCommand Deploy "deploy" "Deploys the current release with the configure options"
     <> addCommand Rollback "rollback" "Rolls back to the previous release"
     )
-

--- a/app/Flag.hs
+++ b/app/Flag.hs
@@ -1,5 +1,6 @@
 module Flag where
 
+import Data.Monoid ((<>))
 import Options.Applicative
 
 data Flag

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -12,9 +12,10 @@ module Options (
   )
   where
 
-import Command as Command
-import Flag as Flag
+import Command
+import Flag
 
+import Data.Monoid ((<>))
 import Options.Applicative
 
 -- | Flags and commands
@@ -24,8 +25,8 @@ opts
   <|> fmap Command commands
 
 data Option
-  = Command (Command.Command)
-  | Flag (Flag.Flag)
+  = Command Command.Command
+  | Flag Flag.Flag
   deriving Show
 
 hapistranoDesc :: InfoMod a
@@ -34,4 +35,3 @@ hapistranoDesc =
     <> header "Hapistrano - A deployment library for Haskell applications"
     <> progDesc "Deploy tool for Haskell applications"
     <> footer "Run 'hap -h' for available commands"
-

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -22,7 +22,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Justin Leitgeb
 maintainer:          justin@stackbuilders.com
-copyright:           2015 Stack Builders Inc.
+copyright:           2015-2017 Stack Builders Inc.
 category:            System
 homepage:            https://github.com/stackbuilders/hapistrano
 bug-reports:         https://github.com/stackbuilders/hapistrano/issues
@@ -30,19 +30,26 @@ build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  changes.md README.md
 
+flag dev
+  description:        Turn on development settings.
+  manual:             True
+  default:            False
+
 library
   hs-source-dirs:      src
   exposed-modules:     System.Hapistrano
   other-modules:       System.Hapistrano.Types
-  build-depends:       base >= 4.5 && < 4.10
-                     , either >= 4.0 && < 4.6
-                     , mtl >= 2.0 && < 3.0
-                     , filepath
-                     , process
-                     , time-locale-compat
-                     , time
-                     , transformers
-  ghc-options:         -Wall
+  build-depends:       base               >= 4.6 && < 5.0
+                     , either             >= 4.0 && < 4.6
+                     , filepath           >= 1.2 && < 1.5
+                     , mtl                >= 2.0 && < 3.0
+                     , process            >= 1.4 && < 1.5
+                     , time               >= 1.5 && < 1.8
+                     , transformers       >= 0.4 && < 0.6
+  if flag(dev)
+    ghc-options:       -Wall -Werror
+  else
+    ghc-options:       -O2 -Wall
   default-language:    Haskell2010
 
 executable hap
@@ -51,11 +58,14 @@ executable hap
   other-modules:       Options
                       , Command
                       , Flag
-  build-depends:       base
+  build-depends:       base               >= 4.6 && < 5.0
+                     , base-compat        >= 0.6 && < 1.0
                      , hapistrano
-                     , base-compat >= 0.6 && < 1.0
                      , optparse-applicative >= 0.11 && < 0.14
-  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  if flag(dev)
+    ghc-options:       -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
+  else
+    ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O2 -Wall
   default-language:    Haskell2010
 
 test-suite hapistrano-test
@@ -63,16 +73,19 @@ test-suite hapistrano-test
   hs-source-dirs:      spec
   main-is:             Spec.hs
   other-modules:       System.HapistranoSpec
-  build-depends:       base >= 4.5 && < 4.10
+  build-depends:       base               >= 4.5 && < 5.0
+                     , directory          >= 1.2.2 && < 1.4
+                     , either             >= 4.0 && < 4.6
+                     , filepath           >= 1.2 && < 1.5
                      , hapistrano
-                     , either >= 4.0 && < 4.6
-                     , hspec > 2.0 && < 2.5
-                     , mtl >= 2.0 && < 3.0
-                     , temporary
-                     , directory
-                     , filepath
-                     , process
-  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+                     , hspec              >= 2.0 && < 3.0
+                     , mtl                >= 2.0 && < 3.0
+                     , process            >= 1.4 && < 1.5
+                     , temporary          >= 1.1 && < 1.3
+  if flag(dev)
+    ghc-options:       -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
+  else
+    ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O2 -Wall
   default-language:    Haskell2010
 
 source-repository head

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -1,7 +1,16 @@
+-- |
+-- Module      :  System.Hapistrano
+-- Copyright   :  © 2017 Stack Builders
+-- License     :  MIT
+--
+-- Maintainer  :  Justin Leitgeb <justin@stackbuilders.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- A module for creating reliable deploy processes for Haskell applications.
+
 {-# LANGUAGE OverloadedStrings #-}
 
--- | A module for easily creating reliable deploy processes for Haskell
--- applications.
 module System.Hapistrano
        ( Config(..)
        , ReleaseFormat(..)
@@ -25,7 +34,6 @@ module System.Hapistrano
 
 import Control.Monad.Reader (ReaderT(..), ask)
 
-
 import System.Hapistrano.Types
   (Config(..), FailureResult, Hapistrano, Release, ReleaseFormat(..))
 
@@ -39,10 +47,8 @@ import Control.Monad.Trans.Either ( left
 
 import Data.Char (isNumber, isSpace)
 import Data.List (intercalate, sortBy, isInfixOf, dropWhileEnd)
-import Data.Time (getCurrentTime)
-import Data.Time.Format (formatTime)
-import Data.Time.Locale.Compat (defaultTimeLocale)
-import System.FilePath.Posix (joinPath, splitPath)
+import Data.Time
+import System.FilePath (joinPath, splitPath)
 import System.IO (hPutStrLn, stderr)
 import System.Process (readProcessWithExitCode)
 
@@ -83,7 +89,6 @@ defaultSuccessHandler :: a -> ReaderT Config IO ()
 defaultSuccessHandler _ =
   liftIO $ putStrLn "Deploy completed successfully."
 
-
 -- | Creates necessary directories for the hapistrano project. Should
 -- only need to run the first time the project is deployed on a given
 -- system.
@@ -93,6 +98,8 @@ setupDirs = do
 
   mapM_ (runCommand (host conf) (port conf))
     ["mkdir -p " ++ releasesPath conf, "mkdir -p " ++ cacheRepoPath conf]
+
+-- | TODO
 
 directoryExists :: Maybe String -> FilePath -> IO Bool
 directoryExists hst path = do
@@ -216,7 +223,6 @@ cloneToRelease = do
 
   return rls
 
-
 -- | Returns the full path to the git repo used for cache purposes on the
 -- target host filesystem.
 cacheRepoPath :: Config -- ^ The Hapistrano configuration
@@ -334,6 +340,8 @@ restartServerCommand = do
     Nothing -> return "No command given for restart action."
     Just cmd -> runCommand (host conf) (port conf) cmd
 
+-- | TODO
+
 cleanBuildScript :: [String] -> [String]
 cleanBuildScript allScriptLines = filter (not . isCommentOrEmpty) allScriptLines
   where
@@ -387,7 +395,6 @@ symlinkCurrent rel = do
                                    , currentTempSymlinkPath conf
                                    , currentSymlinkPath conf ]
 
-
 -- | Updates the git repo used as a cache in the target host filesystem.
 updateCacheRepo :: Hapistrano ()
 updateCacheRepo = do
@@ -425,7 +432,6 @@ buildRelease rel commands = do
   conf <- ask
   let cdCmd = "cd " ++ releasePath conf rel
   void $ runCommand (host conf) (port conf) $ intercalate " && " $ cdCmd : commands
-
 
 -- | A safe version of the `maximum` function in Data.List.
 biggest :: Ord a => [a] -> Maybe a

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -1,3 +1,14 @@
+-- |
+-- Module      :  System.Hapistrano.Types
+-- Copyright   :  © 2017 Stack Builders
+-- License     :  MIT
+--
+-- Maintainer  :  Justin Leitgeb <justin@stackbuilders.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- TODO
+
 module System.Hapistrano.Types
        ( Config(..)
        , FailureResult
@@ -35,6 +46,8 @@ data Config =
 
          } deriving (Show)
 
+-- | TODO
+
 data ReleaseFormat = Short
                      -- ^ Standard release path following Capistrano's format
 
@@ -44,9 +57,14 @@ data ReleaseFormat = Short
 
                    deriving (Show)
 
+-- | TODO
 
 type Release = String
 
+-- | TODO
+
 type FailureResult = (Int, String)
+
+-- | TODO
 
 type Hapistrano a = EitherT FailureResult (ReaderT Config IO) a


### PR DESCRIPTION
We should test with Cabal, not stack, because it allows to test in more adverse environment, test with GHC versions that are not yet in snapshorts, and generally improve compatibility.

This script tests with Cabal 1.24, as it's compatible with all GHC versions of interest and has a better dependency resolution algorithm that allows to avoid some problems with builds.

I also would like to impose 100% Haddock coverage here.