### PR TITLE
Allow copy precompiled files

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,33 @@ $ hap rollback # to rollback to previous successful deploy
 $ hap rollback -n 2 # go two deploys back in time, etc.
 ```
 
-# License
+## What to do when compiling on server is not viable
+
+Sometimes the target machine (server) is not capable of compiling your
+application because e.g. it has not enough memory and GHC exhausts it all.
+You can copy pre-compiled files from local machine or CI server using
+`copy_files` and `copy_dirs` parameters:
+
+```haskell
+copy_files:
+  - src: '/home/stackbuilders/my-file.txt'
+    dest: 'my-file.txt'
+copy_dirs:
+  - src: .stack-work
+    dest: .stack-work
+```
+
+`src` maybe absolute or relative, it's path to file or directory on local
+machine, `dest` may only be relative (it's expanded relatively to cloned
+repo) and specifies where to put the files/directories on target machine.
+Directories and files with clashing names will be overwritten. Directories
+are copied recursively.
+
+## License
 
 MIT, see [the LICENSE file](LICENSE).
 
-# Contributing
+## Contributing
 
 Pull requests for modifications to this program are welcome. Fork and
 open a PR. Feel free to [email me](mailto:justin@stackbuilders.com) if

--- a/src/System/Hapistrano/Commands.hs
+++ b/src/System/Hapistrano/Commands.hs
@@ -80,7 +80,7 @@ data Cd cmd = Cd (Path Abs Dir) cmd
 
 instance Command cmd => Command (Cd cmd) where
   type Result (Cd cmd) = Result cmd
-  renderCommand (Cd path cmd) = "(cd " ++ quote (fromAbsDir path) ++
+  renderCommand (Cd path cmd) = "(cd " ++ quoteCmd (fromAbsDir path) ++
     " && " ++ renderCommand cmd ++ ")"
   parseResult Proxy = parseResult (Proxy :: Proxy cmd)
 
@@ -278,12 +278,12 @@ readScript path = liftIO $ catMaybes . fmap mkGenericCommand . lines
 -- | Format a command.
 
 formatCmd :: String -> [Maybe String] -> String
-formatCmd cmd args = unwords (quote <$> (cmd : catMaybes args))
+formatCmd cmd args = unwords (quoteCmd <$> (cmd : catMaybes args))
 
 -- | Simple-minded quoter.
 
-quote :: String -> String
-quote str =
+quoteCmd :: String -> String
+quoteCmd str =
   if any isSpace str
     then "\"" ++ str ++ "\""
     else str


### PR DESCRIPTION
Close #54. In this version we just allow to copy arbitrary files and directories specified in the configuration. Copying should be quite fast and it's more straightforward than linking across releases, which is probably language-dependent solution (i.e. we know that we want to link `.stack-work`, but with other languages maybe we would want to copy just binary file). In any case the solution implemented here seems to be more general to me.