### PR TITLE
Fix some issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.0.1
+
+* Reduced verbosity of some commands to make reading logs easier.
+* Restart command is now invoked after activation of new release (is it
+  should).
+* Fix a typo in flag that specifies SSH port for `scp`.
+* Ensure that containing directories for files and directories to copy
+  exist before invoking `scp`.
+
 ## 0.3.0.0
 
 * Add proper set of dependency version constraints.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,10 +13,11 @@ import Path.IO
 import Paths_hapistrano (version)
 import System.Exit
 import System.Hapistrano.Types
-import qualified Config as C
-import qualified Data.Yaml as Yaml
-import qualified System.Hapistrano as Hap
-import qualified System.Hapistrano.Core as Hap
+import qualified Config                     as C
+import qualified Data.Yaml                  as Yaml
+import qualified System.Hapistrano          as Hap
+import qualified System.Hapistrano.Commands as Hap
+import qualified System.Hapistrano.Core     as Hap
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
@@ -122,11 +123,15 @@ main = do
           forM_ configCopyFiles $ \(C.CopyThing src dest) -> do
             srcPath  <- resolveFile' src
             destPath <- parseRelFile dest
-            Hap.scpFile srcPath (rpath </> destPath)
+            let dpath = rpath </> destPath
+            (Hap.exec . Hap.MkDir . parent) dpath
+            Hap.scpFile srcPath dpath
           forM_ configCopyDirs $ \(C.CopyThing src dest) -> do
             srcPath  <- resolveDir' src
             destPath <- parseRelDir dest
-            Hap.scpDir srcPath (rpath </> destPath)
+            let dpath = rpath </> destPath
+            (Hap.exec . Hap.MkDir . parent) dpath
+            Hap.scpDir srcPath dpath
           forM_ configBuildScript (Hap.playScript configDeployPath release)
           Hap.registerReleaseAsComplete configDeployPath release
           Hap.activateRelease configDeployPath release

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -128,10 +128,10 @@ main = do
             destPath <- parseRelDir dest
             Hap.scpDir srcPath (rpath </> destPath)
           forM_ configBuildScript (Hap.playScript configDeployPath release)
-          forM_ configRestartCommand Hap.exec
           Hap.registerReleaseAsComplete configDeployPath release
           Hap.activateRelease configDeployPath release
           Hap.dropOldReleases configDeployPath n
+          forM_ configRestartCommand Hap.exec
         Rollback n -> do
           Hap.rollback configDeployPath n
           forM_ configRestartCommand Hap.exec

--- a/src/System/Hapistrano/Commands.hs
+++ b/src/System/Hapistrano/Commands.hs
@@ -103,7 +103,7 @@ data Rm where
 instance Command Rm where
   type Result Rm = ()
   renderCommand (Rm path) = formatCmd "rm"
-    [ Just "-rfv"
+    [ Just "-rf"
     , Just (toFilePath path) ]
   parseResult Proxy _ = ()
 

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -102,7 +102,7 @@ scp' src dest extraArgs = do
       portArg =
         case sshPort <$> configSshOptions of
           Nothing -> []
-          Just x  -> ["-p", show x]
+          Just x  -> ["-P", show x]
       hostPrefix =
         case sshHost <$> configSshOptions of
           Nothing -> ""

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -80,7 +80,7 @@ scpFile
   -> Path Abs File     -- ^ Where to put the file on target machine
   -> Hapistrano ()
 scpFile src dest =
-  scp' (fromAbsFile src) (fromAbsFile dest) ["-qv"]
+  scp' (fromAbsFile src) (fromAbsFile dest) ["-q"]
 
 -- | Copy a local directory recursively to target server.
 
@@ -89,7 +89,7 @@ scpDir
   -> Path Abs Dir      -- ^ Where to put the dir on target machine
   -> Hapistrano ()
 scpDir src dest =
-  scp' (fromAbsDir src) (fromAbsDir dest) ["-qvr"]
+  scp' (fromAbsDir src) (fromAbsDir dest) ["-qr"]
 
 scp'
   :: FilePath


### PR DESCRIPTION
This PR fixes a few issues I faced when I was playing with the new Hapistrano. With these fixes I find the tool quite usable and ready for switching to.

There are also important points about it I'd like to document:

* Changing environment in build script won't work because commands are executed one by one. Solution is to use `&&` to chain `export` and target command to get a single command, like this:

  ```yaml
  build_script:
  - mkdir -p log/
  - touch log/access.log
  - touch log/error.log
  - export DBM_DATABASE="dbname=clearnexus_staging" && export DBM_DATABASE_TYPE=postgresql && export DBM_MIGRATION_STORE=migrations && ~/.local/bin/moo upgrade
  ```

* We should not really copy entire `.stack-work` directory for two reasons: 1) it doesn't seem to work, I get an error about missing files referring to paths on my local system 2) `.stack-work` is actually pretty big, for ClearNexus it's 500+ Mb. So I experimented with copying only binaries and it worked. Below I post the complete configuration file:

  ```yaml
  deploy_path: /var/projects/clearnexus
  host: stackbuilders@staging.clearnex.us
  repo: git@github.com:stackbuilders/clearnexus.git
  revision: origin/master
  build_script:
    - mkdir -p log/
    - touch log/access.log
    - touch log/error.log
    - export DBM_DATABASE="dbname=clearnexus_staging" && export DBM_DATABASE_TYPE=postgresql && export DBM_MIGRATION_STORE=migrations && ~/.local/bin/moo upgrade
  restart_command: sudo systemctl restart clearnexus-app
  copy_files:
    - src:  .stack-work/install/x86_64-linux/lts-6.26/7.10.3/bin/clearnexus
      dest: .stack-work/install/x86_64-linux/lts-6.26/7.10.3/bin/clearnexus
    - src:  .stack-work/install/x86_64-linux/lts-6.26/7.10.3/bin/clearnexus-reporter
      dest: .stack-work/install/x86_64-linux/lts-6.26/7.10.3/bin/clearnexus-reporter
  ```

  This doesn't look bad except that file paths in `copy_files` contain resolver and GHC version in them. So this means when we migrate to newer resolver, we need to remember to update this. Not very nice, but I don't know how to improve the situation.

Latest staging deploy for ClearNexus (file were copied, not compiled on server):

https://staging.clearnex.us

Everything seems to work, and it was really fast.
