### PR TITLE
Add mode hard to reset

### DIFF
--- a/src/System/Hapistrano/Commands.hs
+++ b/src/System/Hapistrano/Commands.hs
@@ -238,6 +238,7 @@ instance Command GitReset where
   type Result GitReset = ()
   renderCommand (GitReset revision) = formatCmd "git"
     [ Just "reset"
+    , Just "--hard"
     , Just revision ]
   parseResult Proxy _ = ()
 


### PR DESCRIPTION
Hapistrano sets the release to the correct revision by resetting the head of the git repository while the current branch is `master`. However, if you want to deploy using a different branch, which has diverged from master, `git reset origin/<new-branch>` will have unstaged changes after reset.

Let me know if this is the intended behavior. Otherwise, I added `--hard` to the `GitReset` command to avoid having unstaged changes. 
