### PR TITLE
Generate help for subcommands

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -58,7 +58,7 @@ parserInfo =
 
 optionParser :: Parser Opts
 optionParser = Opts
-  <$> subparser
+  <$> hsubparser
   ( command "deploy"
     (info deployParser (progDesc "Deploy a new release")) <>
     command "rollback"


### PR DESCRIPTION
This would make optparse-applicative automatically generate help for subcommands.

Previous behaviour:

```bash
$ hap deplo --help
Hapistrano - A deployment library for Haskell applications
Usage: hap [-v|--version] COMMAND [-c|--config PATH]
  Deploy tool for Haskell applications
Available options:
  -h,--help                Show this help text
  -v,--version             Show version of the program
  -c,--config PATH         Configuration file to use (default: "hap.yaml")
Available commands:
  deploy                   Deploy a new release
  rollback                 Roll back to Nth previous release
```

New behavior: 

```bash
$ hap deploy --help
Usage: hap deploy [-r|--release-format ARG] [-k|--keep-releases ARG]
  Deploy a new release
Available options:
  -r,--release-format ARG  Which format release timestamp format to use: ‘long’
                           or ‘short’, default is ‘short’.
  -k,--keep-releases ARG   How many releases to keep (default: 5)
  -h,--help                Show this help text
```