### PR TITLE
Add support for deployment on non-GNU/Linux targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,13 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3],sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
-    - env: CABALVER=2.0 GHCVER=8.2.1
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.2
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
+    - os: osx
 
 before_install:
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install ghc cabal-install; fi
 
 install:
  - cabal --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5.0
+* Add support for deploying to other Unix systems, besides GNU/Linux which
+  didn't supported all the flags that Hapistrano was using. See issue #63
+
 ## 0.3.4.0
 * Use `git checkout` instead of `git reset` to set the release revision
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ The following parameters are *optional*:
 * `vc_action` - Controls if version control related activity should
   take place. It defaults to true. When you don't want activity like
   cloning, fetching etc. to take place, set this to `false`.
+* `linux` - Specify, whether or not, the target system where Hapistrano will
+  deploy to is a GNU/Linux or other UNIX (g.e. BSD, Mac). This is set to `true`
+  by default so unless the target system is not GNU/Linux, this should not be
+  necessary. The platform where Hapistrano is running won't affect the
+  available options for commands (g.e. A Mac deploying to a Ubuntu machine,
+  doesn't need this flag)
 * `run_locally:`- Instructions to run locally on your machine in the
   form of shell commands. Example:
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -151,11 +151,11 @@ main = do
                     Hap.scpDir srcPath dpath
                   forM_ configBuildScript (Hap.playScript configDeployPath release)
                   Hap.registerReleaseAsComplete configDeployPath release
-                  Hap.activateRelease configDeployPath release
+                  Hap.activateRelease configTargetSystem configDeployPath release
                   Hap.dropOldReleases configDeployPath n
                   forM_ configRestartCommand Hap.exec
                 Rollback n -> do
-                  Hap.rollback configDeployPath n
+                  Hap.rollback configTargetSystem configDeployPath n
                   forM_ configRestartCommand Hap.exec
             atomically (writeTChan chan FinishMsg)
             return r

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -1,5 +1,5 @@
 name:                hapistrano
-version:             0.3.4.0
+version:             0.3.5.0
 synopsis:            A deployment library for Haskell applications
 description:
   .

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -18,6 +18,7 @@ module System.Hapistrano.Types
   , SshOptions (..)
   , OutputDest (..)
   , Release
+  , TargetSystem(..)
   , mkRelease
   , releaseTime
   , renderRelease
@@ -85,6 +86,13 @@ data OutputDest
 
 data Release = Release ReleaseFormat UTCTime
   deriving (Eq, Show, Ord)
+
+-- | Target's system where application will be deployed
+
+data TargetSystem
+  = GNULinux
+  | BSD
+  deriving (Eq, Show, Read, Ord, Bounded, Enum)
 
 -- | Create a 'Release' indentifier.
 


### PR DESCRIPTION
Solves #63 

As the issue mentions, some flags are not supported by those UNIX systems which are not Linux. This means that for `mv` and `ln` we can't use `-T` as an argument; and for `readlink` we can't use `-f` in the way we've been doing it.

On this PR, I introduce a new optional key to make explicit the target platform where Hapistrano will deploy. By default, it would asume it's GNU/Linux. On the other hand is explicitly stated, it will now be able to read `linux`, `windows` and any other option will be taken as a BSD system