### PR TITLE
Add support to interpolate ENV variables in a configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.6.0
+* Add support to interpolate ENV variables in a configuration file.
+
 ## 0.3.5.10
 * Updated upper bound for yaml 0.10
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ $ hap rollback # to rollback to previous successful deploy
 $ hap rollback -n 2 # go two deploys back in time, etc.
 ```
 
+### Environment Variables
+
+Configuration files are parsed using
+[loadYamlSettings](http://hackage.haskell.org/package/yaml-0.10.2.0/docs/Data-Yaml-Config.html#v:loadYamlSettings),
+therefore, variable substitution is supported. Considering the following configuration file:
+
+```yaml
+revision: "_env:HAPISTRANO_REVISION:origin/master
+...
+```
+
+The `revision` value could be overwritten as follows:
+
+```sh
+HAPISTRANO_REVISION=origin/feature_branch hap deploy
+```
+
 ## What to do when compiling on server is not viable
 
 Sometimes the target machine (server) is not capable of compiling your

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -1,5 +1,5 @@
 name:                hapistrano
-version:             0.3.5.10
+version:             0.3.6.0
 synopsis:            A deployment library for Haskell applications
 description:
   .
@@ -80,7 +80,7 @@ executable hap
                      , path               >= 0.5 && < 0.7
                      , path-io            >= 1.2 && < 1.5
                      , stm                >= 2.4 && < 2.5
-                     , yaml               >= 0.8 && < 0.11
+                     , yaml               >= 0.8.16 && < 0.11
   if flag(dev)
     ghc-options:       -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   else


### PR DESCRIPTION
### Problem

Sometimes developers need to deploy a feature branch temporarily, therefore providing ENV interpolation support would make it possible to override values in a configuration file. If a configuration file looks as follows:

```yaml
# deploy/staging.yaml
revision: "_env:HAPISTRANO_REVISION:origin/master"
...
```
The revision could be overridden as follows, during the deployment:

```bash
HAPISTRANO_REVISION=origin/feature_branch stack exec hap -- deploy -c deploy/staging.yaml
```

### TODO

- [x] Update README