### PR TITLE
Add process-streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.8.0
+### Added
+* `execWithInheritStdout` was added to `System.Hapistrano.Core` to stream output children's
+to the parent's `stdout`.
+
+### Changed
+* `playScript` and `playScriptLocally` use `execWithInheritStdout` to stream children's
+stdout to parent's stdout.
+
 ## 0.3.7.0
 * Read `release-format` and `keep-releases` from the configuration file.
 

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -1,5 +1,5 @@
 name:                hapistrano
-version:             0.3.7.0
+version:             0.3.8.0
 synopsis:            A deployment library for Haskell applications
 description:
   .
@@ -52,7 +52,6 @@ library
                      , System.Hapistrano.Types
   build-depends:       aeson              >= 0.11 && < 1.5
                      , base               >= 4.8 && < 5.0
-                     , bytestring         >= 0.10 && < 0.11
                      , filepath           >= 1.2 && < 1.5
                      , formatting         >= 6.2 && < 7.0
                      , gitrev             >= 1.2 && < 1.4

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -108,6 +108,7 @@ test-suite test
                      , path-io            >= 1.2 && < 1.5
                      , process            >= 1.4 && < 1.7
                      , QuickCheck         >= 2.5.1 && < 3.0
+                     , silently           >= 1.2 && < 1.3
                      , temporary          >= 1.1 && < 1.4
   if flag(dev)
     ghc-options:       -threaded -rtsopts -with-rtsopts=-N -Wall -Werror

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -57,7 +57,7 @@ library
                      , formatting         >= 6.2 && < 7.0
                      , gitrev             >= 1.2 && < 1.4
                      , mtl                >= 2.0 && < 3.0
-                     , stm                >= 2.4 && < 2.5
+                     , stm                >= 2.0 && < 2.6
                      , path               >= 0.5 && < 0.7
                      , process            >= 1.4 && < 1.7
                      , typed-process      >= 0.2 && < 0.3

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -57,6 +57,7 @@ library
                      , formatting         >= 6.2 && < 7.0
                      , gitrev             >= 1.2 && < 1.4
                      , mtl                >= 2.0 && < 3.0
+                     , stm                >= 2.4 && < 2.5
                      , path               >= 0.5 && < 0.7
                      , process            >= 1.4 && < 1.7
                      , typed-process      >= 0.2 && < 0.3

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -52,14 +52,14 @@ library
                      , System.Hapistrano.Types
   build-depends:       aeson              >= 0.11 && < 1.5
                      , base               >= 4.8 && < 5.0
-                     , bytestring
+                     , bytestring         >= 0.10 && < 0.11
                      , filepath           >= 1.2 && < 1.5
                      , formatting         >= 6.2 && < 7.0
                      , gitrev             >= 1.2 && < 1.4
                      , mtl                >= 2.0 && < 3.0
                      , path               >= 0.5 && < 0.7
                      , process            >= 1.4 && < 1.7
-                     , process-streaming  >= 0.9 && < 1.0
+                     , typed-process      >= 0.2 && < 0.3
                      , time               >= 1.5 && < 1.9
                      , transformers       >= 0.4 && < 0.6
   if flag(dev)

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -52,12 +52,14 @@ library
                      , System.Hapistrano.Types
   build-depends:       aeson              >= 0.11 && < 1.5
                      , base               >= 4.8 && < 5.0
+                     , bytestring
                      , filepath           >= 1.2 && < 1.5
                      , formatting         >= 6.2 && < 7.0
                      , gitrev             >= 1.2 && < 1.4
                      , mtl                >= 2.0 && < 3.0
                      , path               >= 0.5 && < 0.7
                      , process            >= 1.4 && < 1.7
+                     , process-streaming  >= 0.9 && < 1.0
                      , time               >= 1.5 && < 1.9
                      , transformers       >= 0.4 && < 0.6
   if flag(dev)

--- a/spec/System/HapistranoSpec.hs
+++ b/spec/System/HapistranoSpec.hs
@@ -27,11 +27,11 @@ testBranchName = "another_branch"
 
 spec :: Spec
 spec = do
-  describe "exec" $
+  describe "execWithInheritStdout" $
     context "given a command that prints to stdout" $
       it "redirects commands' output to stdout first" $
         let (Just commandTest) = Hap.mkGenericCommand "echo \"hapistrano\"; sleep 2; echo \"onartsipah\""
-            commandExecution = Hap.exec commandTest
+            commandExecution = Hap.execWithInheritStdout commandTest
             expectedOutput = "hapistrano\nonartsipah\n*** localhost ******************************************************************\n$ echo \"hapistrano\"; sleep 2; echo \"onartsipah\"\n"
          in do
            actualOutput <- capture_ (runHap commandExecution)

--- a/spec/System/HapistranoSpec.hs
+++ b/spec/System/HapistranoSpec.hs
@@ -14,6 +14,7 @@ import qualified System.Hapistrano          as Hap
 import qualified System.Hapistrano.Commands as Hap
 import qualified System.Hapistrano.Core     as Hap
 import           System.Hapistrano.Types
+import           System.IO.Silently         (capture_)
 import           System.Info                (os)
 import           System.IO
 import           Test.Hspec                 hiding (shouldBe, shouldReturn)
@@ -26,6 +27,16 @@ testBranchName = "another_branch"
 
 spec :: Spec
 spec = do
+  describe "exec" $
+    context "given a command that prints to stdout" $
+      it "redirects commands' output to stdout first" $
+        let (Just commandTest) = Hap.mkGenericCommand "echo \"hapistrano\"; sleep 2; echo \"onartsipah\""
+            commandExecution = Hap.exec commandTest
+            expectedOutput = "hapistrano\nonartsipah\n*** localhost ******************************************************************\n$ echo \"hapistrano\"; sleep 2; echo \"onartsipah\"\n"
+         in do
+           actualOutput <- capture_ (runHap commandExecution)
+           actualOutput `Hspec.shouldBe` expectedOutput
+
   describe "readScript" $
     it "performs all the necessary normalizations correctly" $ do
       spath <- makeAbsolute $(mkRelFile "script/clean-build.sh")
@@ -79,7 +90,6 @@ spec = do
       context "and the config file value is not present" $
         it "returns the default value" $
           fromMaybeKeepReleases Nothing Nothing `Hspec.shouldBe` 5
-
 
   around withSandbox $ do
     describe "pushRelease" $ do

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -136,7 +136,7 @@ playScript
   -> Hapistrano ()
 playScript deployDir release cmds = do
   rpath <- releasePath deployDir release
-  forM_ cmds (exec . Cd rpath)
+  forM_ cmds (execWithInheritStdout . Cd rpath)
 
 -- | Plays the given script on your machine locally.
 
@@ -147,7 +147,7 @@ playScriptLocally cmds =
         c
         { configSshOptions = Nothing
         }) $
-  forM_ cmds exec
+  forM_ cmds execWithInheritStdout
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -18,6 +18,7 @@ module System.Hapistrano.Core
   ( runHapistrano
   , failWith
   , exec
+  , execWithInheritStdout
   , scpFile
   , scpDir )
 where
@@ -25,15 +26,15 @@ where
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.Reader
+import           Control.Concurrent.STM (atomically)
 import           Data.Proxy
 import           Path
 import           System.Exit
 import           System.Hapistrano.Commands
 import           System.Hapistrano.Types
 import           System.Process
-import           System.Process.Streaming
-import           Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy.Char8 as L8
+import           System.Process.Typed (ProcessConfig)
+import qualified System.Process.Typed as SPT
 
 -- | Run the 'Hapistrano' monad. The monad hosts 'exec' actions.
 
@@ -63,6 +64,9 @@ failWith n msg = throwError (Failure n msg)
 -- determined from settings contained in the 'Hapistrano' monad
 -- configuration. Commands that return non-zero exit codes will result in
 -- short-cutting of execution.
+-- __NOTE:__ the commands executed with 'exec' will create their own pipe and
+-- will stream output there and once the command finishes its execution it will
+-- parse the result.
 
 exec :: forall a. Command a => a -> Hapistrano (Result a)
 exec typedCmd = do
@@ -74,7 +78,36 @@ exec typedCmd = do
           Just SshOptions {..} ->
             ("ssh", [sshHost, "-p", show sshPort, cmd])
       cmd = renderCommand typedCmd
-  parseResult (Proxy :: Proxy a) <$> exec' prog args cmd
+  parseResult (Proxy :: Proxy a) <$> exec' cmd (readProcessWithExitCode prog args "")
+
+-- | Same as 'exec' but it streams to stdout only for _GenericCommand_s
+
+execWithInheritStdout :: Command a => a -> Hapistrano ()
+execWithInheritStdout typedCmd = do
+  Config {..} <- ask
+  let (prog, args) =
+        case configSshOptions of
+          Nothing ->
+            ("bash", ["-c", cmd])
+          Just SshOptions {..} ->
+            ("ssh", [sshHost, "-p", show sshPort, cmd])
+      cmd = renderCommand typedCmd
+  void $ exec' cmd (readProcessWithExitCode' (SPT.proc prog args))
+    where
+    -- | Prepares a process, reads @stdout@ and @stderr@ and returns exit code
+    -- NOTE: @strdout@ and @stderr@ are empty string because we're writing
+    -- the output to the parent.
+    readProcessWithExitCode'
+      :: ProcessConfig stdin stdoutIgnored stderrIgnored
+      -> IO (ExitCode, String, String)
+    readProcessWithExitCode' pc =
+      SPT.withProcess pc' $ \p -> atomically $
+        (,,) <$> SPT.waitExitCodeSTM p
+             <*> return ""
+             <*> return ""
+        where
+          pc' = SPT.setStdout SPT.inherit
+              $ SPT.setStderr SPT.inherit pc
 
 -- | Copy a file from local path to target server.
 
@@ -111,7 +144,7 @@ scp' src dest extraArgs = do
           Nothing -> ""
           Just x  -> x ++ ":"
       args = extraArgs ++ portArg ++ [src, hostPrefix ++ dest]
-  void (exec' prog args (prog ++ " " ++ unwords args))
+  void (exec' (prog ++ " " ++ unwords args) (readProcessWithExitCode prog args ""))
 
 ----------------------------------------------------------------------------
 -- Helpers
@@ -119,43 +152,26 @@ scp' src dest extraArgs = do
 -- | A helper for 'exec' and similar functions.
 
 exec'
-  :: String            -- ^ Name of program to run
-  -> [String]          -- ^ Arguments to that program
-  -> String            -- ^ How to show the command in print-outs
+  :: String            -- ^ How to show the command in print-outs
+  -> IO (ExitCode, String, String) -- ^ TODO
   -> Hapistrano String -- ^ Raw stdout output of that program
-exec' prog args cmd = do
+exec' cmd readProcessOutput = do
   Config {..} <- ask
   let hostLabel =
         case configSshOptions of
           Nothing              -> "localhost"
           Just SshOptions {..} -> sshHost ++ ":" ++ show sshPort
   liftIO $ configPrint StdoutDest (putLine hostLabel ++ "$ " ++ cmd ++ "\n")
-  (exitCode_, stdout_, stderr_) <- liftIO
-    (readProcessWithExitCode' prog args)
-  let stdout' = L8.unpack stdout_
-      stderr' = L8.unpack stderr_
+  (exitCode', stdout', stderr') <- liftIO readProcessOutput
   unless (null stdout') . liftIO $
     configPrint StdoutDest stdout'
   unless (null stderr') . liftIO $
     configPrint StderrDest stderr'
-  case exitCode_ of
+  case exitCode' of
     ExitSuccess ->
       return stdout'
     ExitFailure n ->
       failWith n Nothing
-
--- | Prepares a process, reads stdout and stderr and returns exit code
-
-readProcessWithExitCode'
-  :: String
-  -> [String]
-  -> IO (ExitCode, ByteString, ByteString)
-readProcessWithExitCode' prog args =
-  let command = proc prog args
-   in execute command $
-          (,,) <$> exitCode
-               <*> foldOut intoLazyBytes
-               <*> foldErr intoLazyBytes
 
 -- | Put something “inside” a line, sort-of beautifully.
 

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -153,7 +153,7 @@ scp' src dest extraArgs = do
 
 exec'
   :: String            -- ^ How to show the command in print-outs
-  -> IO (ExitCode, String, String) -- ^ TODO
+  -> IO (ExitCode, String, String) -- ^ Handler to get (ExitCode, Output, Error) it can change accordingly to @stdout@ and @stderr@ of child process
   -> Hapistrano String -- ^ Raw stdout output of that program
 exec' cmd readProcessOutput = do
   Config {..} <- ask

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,3 @@
 resolver: lts-12.13
-extra-deps:
-  - conceit-0.4.0.0
-  - pipes-text-0.0.2.5
-  - pipes-transduce-0.4.4.0
-  - process-streaming-0.9.3.0
-  - streaming-commons-0.1.19
 packages:
   - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,9 @@
 resolver: lts-12.13
+extra-deps:
+  - conceit-0.4.0.0
+  - pipes-text-0.0.2.5
+  - pipes-transduce-0.4.4.0
+  - process-streaming-0.9.3.0
+  - streaming-commons-0.1.19
 packages:
   - '.'


### PR DESCRIPTION
Solves issue #75 

# Description
I'm using [process-streaming](https://hackage.haskell.org/package/typed-process) to run a process. 
```
    readProcessWithExitCode'
      :: ProcessConfig stdin stdoutIgnored stderrIgnored
      -> IO (ExitCode, String, String)
    readProcessWithExitCode' pc =
      SPT.withProcess pc' $ \p -> atomically $
        (,,) <$> SPT.waitExitCodeSTM p
             <*> return ""
             <*> return ""
        where
          pc' = SPT.setStdout SPT.inherit
              $ SPT.setStderr SPT.inherit pc
```
All the magic is in that function ^^. The `readProcessWithExitCode'` method will execute a process but streaming output to `std[out,err]` of its parent (in our case `hap`).

It is good to note that `proc :: FilePath -> [String] -> CreateProcess` sets `std[in,out,err]` to `Inherit` so it will stream the process output to the parent process, also I'm not exactly sure how to tests these. I was thinking about something like:

```
describe "exec" $
  context "when a process is executed" $
     it "should stream process output" $
                 let (Just commandTest) = Hap.mkGenericCommand "echo \"hapistrano\"; sleep 2; echo \"onartsipah\""
            commandExecution = Hap.exec commandTest
            expectedOutput = "hapistrano\nonartsipah\n*** localhost ******************************************************************\n$ echo \"hapistrano\"; sleep 2; echo \"onartsipah\"\n"
         in do
           actualOutput <- capture_ (runHap commandExecution)
           actualOutput `Hspec.shouldBe` expectedOutput
```

@juanpaucar @sestrella @javcasas What do you think? Do we need more tests? (If so, could you please give me a suggestion)

## TODO:
- [x] Adding at least a simple test
- [x] Fix failing tests