### PR TITLE
Bump version from 0.3.9.1 to 0.3.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.9.2
+### Changed
+* Update Docker base image from alpine:3.7 to alpine:3.9
+
 ## 0.3.9.1
 ### Added
 * Add timestamp to output commands:

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -1,5 +1,5 @@
 name:                hapistrano
-version:             0.3.9.1
+version:             0.3.9.2
 synopsis:            A deployment library for Haskell applications
 description:
   .


### PR DESCRIPTION
**Why do we need to bump the version?**

Docker Hub only tags a new release after a new tag gets push to GH or after merging a PR in master following the rules describing below:

![image](https://user-images.githubusercontent.com/2049686/52438008-46316e00-2ae6-11e9-9964-1bb14156872a.png)

Therefore the latest changes introduced to the image is only available as `latest` which is why we need to push a new tag:

![image](https://user-images.githubusercontent.com/2049686/52438109-8395fb80-2ae6-11e9-8551-f30ed11be5c3.png)

**TODO**

- [ ] Upload version to Hackage