### PR TITLE
[#143] Allow optparse-applicative-0.16.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1.2
+### Changed
+* Allow optparse-applicative-0.16.0.0
+
 ## 0.4.1.1
 ### Changed
 * Allow `ansi-terminal` 0.11

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -1,5 +1,5 @@
 name:                hapistrano
-version:             0.4.1.1
+version:             0.4.1.2
 synopsis:            A deployment library for Haskell applications
 description:
   .
@@ -83,7 +83,7 @@ executable hap
                      , formatting         >= 6.2 && < 7.0
                      , gitrev             >= 1.2 && < 1.4
                      , hapistrano
-                     , optparse-applicative >= 0.11 && < 0.16
+                     , optparse-applicative >= 0.11 && < 0.17
                      , path               >= 0.5 && < 0.8
                      , path-io            >= 1.2 && < 1.7
                      , stm                >= 2.4 && < 2.6


### PR DESCRIPTION
I run some tests locally forcing optparse-applicative-0.16.0.0 here are the results:

```diff
 resolver: lts-16.9
 packages:
   - '.'
-
+extra-deps:
+  - optparse-applicative-0.16.0.0
```

Dependencies:

```
➜ stack ls dependencies | grep optparse
optparse-applicative 0.16.0.0
```

Test output:

```
➜ stack test
...
hapistrano> Test suite test passed
```