### PR TITLE
Added `keep_one_failed` option that deletes failed releases except for the latest one

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Compile project
         run: cabal build --enable-tests
       - run: cabal test --enable-tests
-      - run: cabal haddock | grep "100%" | wc -l | grep -G "[45]" # Fixes issue with different haddock coverage with different ghc versions https://github.com/haskell/haddock/issues/123
+      - run: cabal haddock | grep "100%" | wc -l | grep -E "[4-9]|[1-9][0-9]+" # Fixes issue with different haddock coverage with different ghc versions https://github.com/haskell/haddock/issues/123
       - run: cabal sdist
       - if: matrix.ghc == '8.8.4'
         name: Login to Docker Hub

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ The following parameters are *optional*:
   '--keep-releases' argument passed via the CLI takes precedence over this
   value. If neither CLI nor configuration file value is specified, it defaults
   to '5'
+* `keep_one_failed` - A boolean specifying whether to keep all failed releases
+  or just one (the latest failed release), the '--keep-one-failed' flag passed via
+  the CLI takes precedence over this value. If neither CLI nor configuration file value is specified,
+  it defaults to false (i.e. keep all failed releases).
 * `linked_files:`- Listed files that will be symlinked from the `{deploy_path}/shared` folder
 into each release directory during deployment. Can be used for configuration files
 that need to be persisted (e.g. dotenv files).  **NOTE:** The directory structure _must_

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,10 +8,9 @@ module Main (main) where
 import           Control.Concurrent.Async
 import           Control.Concurrent.STM
 import           Control.Monad
-
-
-
-
+#if !MIN_VERSION_base(4,13,0)
+import           Data.Monoid                ((<>))
+#endif
 import           Data.Version               (showVersion)
 import qualified Data.Yaml.Config           as Yaml
 import           Development.GitRev

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -82,7 +82,7 @@ deployParser = Deploy
         )
   <*> switch
             ( long "keep-one-failed"
-            <> short 'f'
+            <> short 'o'
             <> help "Keep all failed releases or just one -the latest-, default (without using this flag) is to keep all failed releases."
             )
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -81,10 +81,9 @@ deployParser = Deploy
             )
         )
   <*> switch
-            ( long "keep-one-failed"
-            <> short 'o'
+        ( long "keep-one-failed"
             <> help "Keep all failed releases or just one -the latest-, default (without using this flag) is to keep all failed releases."
-            )
+        )
 
 rollbackParser :: Parser Command
 rollbackParser = Rollback

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -166,6 +166,7 @@ main = do
                 Hap.activateRelease configTargetSystem configDeployPath release
                 forM_ configRestartCommand (flip Hap.exec $ Just release)
                 Hap.createHapistranoDeployState configDeployPath release System.Hapistrano.Types.Success
+                Hap.dropOldReleases configDeployPath keepReleases keepOneFailed 
               `catchError` failStateAndThrow
             Rollback n -> do
               Hap.rollback configTargetSystem configDeployPath n

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -165,7 +165,6 @@ main = do
                   $ flip (Hap.linkToShared configTargetSystem rpath configDeployPath) (Just release)
                 forM_ configBuildScript (Hap.playScript configDeployPath release configWorkingDir)
                 Hap.activateRelease configTargetSystem configDeployPath release
-                -- Hap.dropOldReleases configDeployPath keepReleases keepOneFailed
                 forM_ configRestartCommand (flip Hap.exec $ Just release)
                 Hap.createHapistranoDeployState configDeployPath release System.Hapistrano.Types.Success
               `catchError` failStateAndThrow

--- a/example/example.cabal
+++ b/example/example.cabal
@@ -5,7 +5,7 @@ description:
   This is an example project that has been created in order to test
   the deployment process using the working_dir feature of hapistrano.
 author:         Justin Leitgeb
-maintainer:     jpaucar@stackbuilders.com
+maintainer:     cmotoche@stackbuilders.com
 copyright:      2015-Present Stack Builders Inc.
 license:        MIT
 license-file:   ../LICENSE

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -82,6 +82,7 @@ executable hap
                      , formatting         >= 6.2 && < 8.0
                      , gitrev             >= 1.2 && < 1.4
                      , hapistrano
+                     , mtl                >= 2.0 && < 3.0
                      , optparse-applicative >= 0.11 && < 0.17
                      , path               >= 0.5 && < 0.9
                      , path-io            >= 1.2 && < 1.7

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -21,7 +21,7 @@ description:
 license:             MIT
 license-file:        LICENSE
 author:              Justin Leitgeb
-maintainer:          jpaucar@stackbuilders.com
+maintainer:          cmotoche@stackbuilders.com
 copyright:           2015-Present Stack Builders Inc.
 category:            System
 homepage:            https://github.com/stackbuilders/hapistrano

--- a/spec/System/HapistranoConfigSpec.hs
+++ b/spec/System/HapistranoConfigSpec.hs
@@ -62,5 +62,6 @@ defaultConfiguration =
     , configTargetSystem = GNULinux
     , configReleaseFormat = Nothing
     , configKeepReleases = Nothing
+    , configKeepOneFailed = False
     , configWorkingDir = Nothing
     }

--- a/spec/System/HapistranoSpec.hs
+++ b/spec/System/HapistranoSpec.hs
@@ -30,6 +30,7 @@ import qualified Test.Hspec as Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck hiding (Success)
 import System.Hapistrano (releasePath)
+import System.Hapistrano.Config (deployStateFilename)
 
 testBranchName :: String
 testBranchName = "another_branch"
@@ -173,7 +174,7 @@ spec = do
           release <- Hap.pushRelease task
           Hap.createHapistranoDeployState deployPath release Success
           Hap.deployState deployPath Nothing release `shouldReturn`
-            Just Success
+            Success
 
     describe "activateRelease" $
       it "creates the ‘current’ symlink correctly" $ \(deployPath, repoPath) ->

--- a/spec/System/HapistranoSpec.hs
+++ b/spec/System/HapistranoSpec.hs
@@ -157,11 +157,11 @@ spec = do
         -- This fails if there are unstaged changes
           justExec rpath "git diff --exit-code"
     describe "createHapistranoDeployState" $ do
-      it "creates the .hapistrano_deploy_state file correctly" $ \(deployPath, repoPath) ->
+      it ("creates the " <> deployStateFilename <> " file correctly") $ \(deployPath, repoPath) ->
         runHap $ do
           let task = mkTask deployPath repoPath
           release <- Hap.pushRelease task
-          parseStatePath <- parseRelFile ".hapistrano_deploy_state"
+          parseStatePath <- parseRelFile deployStateFilename
           actualReleasePath <- releasePath deployPath release Nothing
           let stateFilePath = actualReleasePath </> parseStatePath
           Hap.createHapistranoDeployState deployPath release Success
@@ -194,7 +194,7 @@ spec = do
               task = mkTask deployPath repoPath
           Hap.playScriptLocally localCommands
           release <- Hap.pushRelease task
-          parseStatePath <- parseRelFile ".hapistrano_deploy_state"
+          parseStatePath <- parseRelFile deployStateFilename
           actualReleasePath <- releasePath deployPath release Nothing
           let stateFilePath = actualReleasePath </> parseStatePath
           Hap.createHapistranoDeployState deployPath release Success

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -45,6 +45,7 @@ import           Path
 import           System.Hapistrano.Commands
 import           System.Hapistrano.Core
 import           System.Hapistrano.Types
+import           System.Hapistrano.Config (deployStateFilename)
 import           Text.Read (readMaybe)
 
 ----------------------------------------------------------------------------
@@ -127,7 +128,7 @@ createHapistranoDeployState
   -> DeployState -- ^ Indicates how the deployment went
   -> Hapistrano ()
 createHapistranoDeployState deployPath release state = do
-  parseStatePath <- parseRelFile ".hapistrano_deploy_state"
+  parseStatePath <- parseRelFile deployStateFilename 
   actualReleasePath <- releasePath deployPath release Nothing
   let stateFilePath = actualReleasePath </> parseStatePath
   exec (Touch stateFilePath) (Just release) -- creates '.hapistrano_deploy_state'
@@ -361,7 +362,7 @@ deployState
   -> Release -- ^ 'Release' identifier
   -> Hapistrano (Maybe DeployState) -- ^ Whether the release was deployed successfully or not
 deployState deployPath mWorkingDir release = do
-  parseStatePath <- parseRelFile ".hapistrano_deploy_state"
+  parseStatePath <- parseRelFile deployStateFilename
   actualReleasePath <- releasePath deployPath release mWorkingDir
   let stateFilePath = actualReleasePath </> parseStatePath
   doesExist <- exec (CheckExists stateFilePath) (Just release)

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -274,10 +274,8 @@ releasesWithState selectedState deployPath = do
     ) releases
   where
     stateToBool :: Maybe DeployState -> Bool
-    stateToBool mDeployState =
-      case mDeployState of
-        (Just Fail) -> False
-        _ -> True
+    stateToBool (Just Fail) = False
+    stateToBool _ = True
 
 ----------------------------------------------------------------------------
 -- Path helpers

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -133,7 +133,7 @@ dropOldReleases deployPath n = do
     exec (Rm rpath)
   creleases <- completedReleases deployPath
   forM_ (genericDrop n creleases) $ \release -> do
-    cpath <- ctokenPath  deployPath release
+    cpath <- ctokenPath deployPath release
     exec (Rm cpath)
 
 -- | Play the given script switching to directory of given release.
@@ -189,7 +189,7 @@ ensureCacheInPlace repo deployPath = do
     exec (GitClone True (Left repo) cpath)
   exec (Cd cpath (GitFetch "origin")) -- TODO store this in task description?
 
--- | Create a new realese identifier based on current timestamp.
+-- | Create a new release identifier based on current timestamp.
 
 newRelease :: ReleaseFormat -> Hapistrano Release
 newRelease releaseFormat =

--- a/src/System/Hapistrano/Commands.hs
+++ b/src/System/Hapistrano/Commands.hs
@@ -26,6 +26,8 @@ module System.Hapistrano.Commands
   , Readlink(..)
   , Find(..)
   , Touch(..)
+  , Cat(..)
+  , CheckExists(..)
   , BasicWrite(..)
   , GitCheckout(..)
   , GitClone(..)

--- a/src/System/Hapistrano/Commands.hs
+++ b/src/System/Hapistrano/Commands.hs
@@ -26,6 +26,7 @@ module System.Hapistrano.Commands
   , Readlink(..)
   , Find(..)
   , Touch(..)
+  , BasicWrite(..)
   , GitCheckout(..)
   , GitClone(..)
   , GitFetch(..)

--- a/src/System/Hapistrano/Commands.hs
+++ b/src/System/Hapistrano/Commands.hs
@@ -3,7 +3,7 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Juan Paucar <jpaucar@stackbuilders.com>
+-- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --

--- a/src/System/Hapistrano/Commands/Internal.hs
+++ b/src/System/Hapistrano/Commands/Internal.hs
@@ -198,6 +198,9 @@ instance Command Touch where
   renderCommand (Touch path) = formatCmd "touch" [Just (fromAbsFile path)]
   parseResult Proxy _ = ()
 
+-- | Command that checks for the existance of a particular
+-- file in the host.
+
 newtype CheckExists =
   CheckExists
   (Path Abs File) -- ^ The absolute path to the file you want to check for existence
@@ -207,6 +210,9 @@ instance Command CheckExists where
   renderCommand (CheckExists path) = 
     "([ -r " <> fromAbsFile path <> " ] && echo True) || echo False"
   parseResult Proxy = read
+
+-- | Command used to read the contents of a particular
+-- file in the host.
 
 newtype Cat =
   Cat

--- a/src/System/Hapistrano/Commands/Internal.hs
+++ b/src/System/Hapistrano/Commands/Internal.hs
@@ -3,7 +3,7 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Juan Paucar <jpaucar@stackbuilders.com>
+-- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --

--- a/src/System/Hapistrano/Commands/Internal.hs
+++ b/src/System/Hapistrano/Commands/Internal.hs
@@ -198,6 +198,22 @@ instance Command Touch where
   renderCommand (Touch path) = formatCmd "touch" [Just (fromAbsFile path)]
   parseResult Proxy _ = ()
 
+-- | Basic command that writes to a file some contents.
+-- It uses the @file > contents@ shell syntax and the @contents@ is
+-- represented as a 'String', so it shouldn't be used for
+-- bigger writing operations. Currently used to write @fail@ or @success@
+-- to the @.hapistrano_deploy_state@ file.
+data BasicWrite =
+  BasicWrite 
+  (Path Abs File) -- ^ The absolute path to the file to which you want to write
+  String -- ^ The contents that will be written to the file
+
+instance Command BasicWrite where
+  type Result BasicWrite = ()
+  renderCommand (BasicWrite path contents) =
+     "echo \"" <> contents <> "\"" <> " > " <> fromAbsFile path
+  parseResult Proxy _ = ()
+
 -- | Git checkout.
 data GitCheckout =
   GitCheckout String

--- a/src/System/Hapistrano/Commands/Internal.hs
+++ b/src/System/Hapistrano/Commands/Internal.hs
@@ -67,7 +67,7 @@ instance Command cmd => Command (Cd cmd) where
   parseResult Proxy = parseResult (Proxy :: Proxy cmd)
 
 -- | Create a directory. Does not fail if the directory already exists.
-data MkDir =
+newtype MkDir =
   MkDir (Path Abs Dir)
 
 instance Command MkDir where
@@ -151,7 +151,7 @@ instance Command (Readlink Dir) where
 
 -- | @ls@, so far used only to check existence of directories, so it's not
 -- very functional right now.
-data Ls =
+newtype Ls =
   Ls (Path Abs Dir)
 
 instance Command Ls where
@@ -190,13 +190,32 @@ instance Command (Find File) where
   parseResult Proxy = mapMaybe (parseAbsFile . trim) . lines
 
 -- | @touch@.
-data Touch =
+newtype Touch =
   Touch (Path Abs File)
 
 instance Command Touch where
   type Result Touch = ()
   renderCommand (Touch path) = formatCmd "touch" [Just (fromAbsFile path)]
   parseResult Proxy _ = ()
+
+newtype CheckExists =
+  CheckExists
+  (Path Abs File) -- ^ The absolute path to the file you want to check for existence
+
+instance Command CheckExists where
+  type Result CheckExists = Bool
+  renderCommand (CheckExists path) = 
+    "([ -r " <> fromAbsFile path <> " ] && echo True) || echo False"
+  parseResult Proxy = read
+
+newtype Cat =
+  Cat
+  (Path Abs File) -- ^ The absolute path to the file you want to read
+
+instance Command Cat where
+  type Result Cat = String
+  renderCommand (Cat path) = formatCmd "cat" [Just (fromAbsFile path)]
+  parseResult Proxy = id 
 
 -- | Basic command that writes to a file some contents.
 -- It uses the @file > contents@ shell syntax and the @contents@ is
@@ -215,7 +234,7 @@ instance Command BasicWrite where
   parseResult Proxy _ = ()
 
 -- | Git checkout.
-data GitCheckout =
+newtype GitCheckout =
   GitCheckout String
 
 instance Command GitCheckout where
@@ -246,7 +265,7 @@ instance Command GitClone where
   parseResult Proxy _ = ()
 
 -- | Git fetch (simplified).
-data GitFetch =
+newtype GitFetch =
   GitFetch String
 
 instance Command GitFetch where
@@ -258,7 +277,7 @@ instance Command GitFetch where
   parseResult Proxy _ = ()
 
 -- | Git reset.
-data GitReset =
+newtype GitReset =
   GitReset String
 
 instance Command GitReset where
@@ -268,7 +287,7 @@ instance Command GitReset where
   parseResult Proxy _ = ()
 
 -- | Weakly-typed generic command, avoid using it directly.
-data GenericCommand =
+newtype GenericCommand =
   GenericCommand String
   deriving (Show, Eq, Ord)
 

--- a/src/System/Hapistrano/Config.hs
+++ b/src/System/Hapistrano/Config.hs
@@ -47,7 +47,7 @@ data Config = Config
   , configLinkedDirs       :: ![FilePath]
     -- ^ Collection of directories to link from each release to _shared_
   , configVcAction       :: !Bool
-  -- ^ Perform version control related actions. By default, it's assumed to be True.
+  -- ^ Perform version control related actions. By default, it's assumed to be `True`.
   , configRunLocally     :: !(Maybe [GenericCommand])
   -- ^ Perform a series of commands on the local machine before communication
   -- with target server starts
@@ -55,13 +55,19 @@ data Config = Config
   -- ^ Optional parameter to specify the target system. It's GNU/Linux by
   -- default
   , configReleaseFormat  :: !(Maybe ReleaseFormat)
-  -- ^ The release timestamp format, the '--release-format' argument passed via
+  -- ^ The release timestamp format, the @--release-format@ argument passed via
   -- the CLI takes precedence over this value. If neither CLI or configuration
   -- file value is specified, it defaults to short
   , configKeepReleases   :: !(Maybe Natural)
-  -- ^ The number of releases to keep, the '--keep-releases' argument passed via
+  -- ^ The number of releases to keep, the @--keep-releases@ argument passed via
   -- the CLI takes precedence over this value. If neither CLI or configuration
   -- file value is specified, it defaults to 5
+  , configKeepOneFailed :: !Bool
+  -- ^ Specifies whether to keep all failed releases along with the successful releases
+  -- or just the latest failed (at least this one should be kept for debugging purposes).
+  -- The @--keep-one-failed@ argument passed via the CLI takes precedence over this value.
+  -- If neither CLI or configuration file value is specified, it defaults to `False` 
+  -- (i.e. keep all failed releases).
   , configWorkingDir :: !(Maybe (Path Rel Dir))
   } deriving (Eq, Ord, Show)
 
@@ -116,6 +122,7 @@ instance FromJSON Config where
     configTargetSystem <- o .:? "linux" .!= GNULinux
     configReleaseFormat <- o .:? "release_format"
     configKeepReleases <- o .:? "keep_releases"
+    configKeepOneFailed <- o .:? "keep_one_failed" .!= False
     configWorkingDir <- o .:? "working_directory"
     return Config {..}
 

--- a/src/System/Hapistrano/Config.hs
+++ b/src/System/Hapistrano/Config.hs
@@ -1,3 +1,14 @@
+-- |
+-- Module      :  System.Config
+-- Copyright   :  © 2015-Present Stack Builders
+-- License     :  MIT
+--
+-- Maintainer  :  Juan Paucar <jpaucar@stackbuilders.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Definitions for types and functions related to the configuration
+-- of the Hapistrano tool.
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -78,6 +89,8 @@ data Config = Config
 data CopyThing = CopyThing FilePath FilePath
   deriving (Eq, Ord, Show)
 
+-- | Datatype that holds information about the target host.
+
 data Target =
   Target
     { targetHost    :: String
@@ -142,6 +155,9 @@ mkCmd raw =
   case mkGenericCommand raw of
     Nothing  -> fail "invalid restart command"
     Just cmd -> return cmd
+
+-- | Constant with the name of the file used to store 
+-- the deployment state information.
 
 deployStateFilename :: String 
 deployStateFilename = ".hapistrano_deploy_state"

--- a/src/System/Hapistrano/Config.hs
+++ b/src/System/Hapistrano/Config.hs
@@ -7,7 +7,8 @@
 module System.Hapistrano.Config
   ( Config (..)
   , CopyThing (..)
-  , Target (..))
+  , Target (..)
+  , deployStateFilename)
 where
 
 import           Control.Applicative        ((<|>))
@@ -141,3 +142,6 @@ mkCmd raw =
   case mkGenericCommand raw of
     Nothing  -> fail "invalid restart command"
     Just cmd -> return cmd
+
+deployStateFilename :: String 
+deployStateFilename = ".hapistrano_deploy_state"

--- a/src/System/Hapistrano/Config.hs
+++ b/src/System/Hapistrano/Config.hs
@@ -3,7 +3,7 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Juan Paucar <jpaucar@stackbuilders.com>
+-- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -14,8 +14,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module System.Hapistrano.Core
-  ( runHapistrano
-  , failWith
+  ( failWith
   , exec
   , execWithInheritStdout
   , scpFile
@@ -32,34 +31,10 @@ import           Path
 import           System.Console.ANSI
 import           System.Exit
 import           System.Hapistrano.Commands
-import           System.Hapistrano.Types
+import           System.Hapistrano.Types hiding (Command)
 import           System.Process
 import           System.Process.Typed       (ProcessConfig)
 import qualified System.Process.Typed       as SPT
-
--- | Run the 'Hapistrano' monad. The monad hosts 'exec' actions.
-runHapistrano ::
-     MonadIO m
-  => Maybe SshOptions -- ^ SSH options to use or 'Nothing' if we run locally
-  -> Shell -- ^ Shell to run commands
-  -> (OutputDest -> String -> IO ()) -- ^ How to print messages
-  -> Hapistrano a -- ^ The computation to run
-  -> m (Either Int a) -- ^ Status code in 'Left' on failure, result in
-              -- 'Right' on success
-runHapistrano sshOptions shell' printFnc m =
-  liftIO $ do
-    let config =
-          Config
-            { configSshOptions = sshOptions
-            , configShellOptions = shell'
-            , configPrint = printFnc
-            }
-    r <- runReaderT (runExceptT m) config
-    case r of
-      Left (Failure n msg) -> do
-        forM_ msg (printFnc StderrDest)
-        return (Left n)
-      Right x -> return (Right x)
 
 -- | Fail returning the following status code and message.
 failWith :: Int -> Maybe String -> Hapistrano a

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -37,8 +37,8 @@ import           System.Process.Typed       (ProcessConfig)
 import qualified System.Process.Typed       as SPT
 
 -- | Fail returning the following status code and message.
-failWith :: Int -> Maybe String -> Hapistrano a
-failWith n msg = throwError (Failure n msg)
+failWith :: Int -> Maybe String -> Maybe Release -> Hapistrano a
+failWith n msg maybeRelease = throwError (Failure n msg, maybeRelease)
 
 -- | Run the given sequence of command. Whether to use SSH or not is
 -- determined from settings contained in the 'Hapistrano' monad
@@ -49,20 +49,25 @@ failWith n msg = throwError (Failure n msg)
 -- parse the result.
 exec ::
      forall a. Command a
-  => a
+  => a -- ^ Command being executed
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
   -> Hapistrano (Result a)
-exec typedCmd = do
+exec typedCmd maybeRelease = do
   let cmd = renderCommand typedCmd
   (prog, args) <- getProgAndArgs cmd
   parseResult (Proxy :: Proxy a) <$>
-    exec' cmd (readProcessWithExitCode prog args "")
+    exec' cmd (readProcessWithExitCode prog args "") maybeRelease
 
 -- | Same as 'exec' but it streams to stdout only for _GenericCommand_s
-execWithInheritStdout :: Command a => a -> Hapistrano ()
-execWithInheritStdout typedCmd = do
+execWithInheritStdout ::
+     Command a 
+  => a -- ^ Command being executed
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
+  -> Hapistrano ()
+execWithInheritStdout typedCmd maybeRelease = do
   let cmd = renderCommand typedCmd
   (prog, args) <- getProgAndArgs cmd
-  void $ exec' cmd (readProcessWithExitCode' (SPT.proc prog args))
+  void $ exec' cmd (readProcessWithExitCode' (SPT.proc prog args)) maybeRelease
     where
     -- | Prepares a process, reads @stdout@ and @stderr@ and returns exit code
     -- NOTE: @strdout@ and @stderr@ are empty string because we're writing
@@ -95,6 +100,7 @@ getProgAndArgs cmd = do
 scpFile ::
      Path Abs File -- ^ Location of the file to copy
   -> Path Abs File -- ^ Where to put the file on target machine
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
   -> Hapistrano ()
 scpFile src dest = scp' (fromAbsFile src) (fromAbsFile dest) ["-q"]
 
@@ -102,11 +108,12 @@ scpFile src dest = scp' (fromAbsFile src) (fromAbsFile dest) ["-q"]
 scpDir ::
      Path Abs Dir -- ^ Location of the directory to copy
   -> Path Abs Dir -- ^ Where to put the dir on target machine
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
   -> Hapistrano ()
 scpDir src dest = scp' (fromAbsDir src) (fromAbsDir dest) ["-qr"]
 
-scp' :: FilePath -> FilePath -> [String] -> Hapistrano ()
-scp' src dest extraArgs = do
+scp' :: FilePath -> FilePath -> [String] -> Maybe Release -> Hapistrano ()
+scp' src dest extraArgs maybeRelease = do
   Config {..} <- ask
   let prog = "scp"
       portArg =
@@ -119,7 +126,7 @@ scp' src dest extraArgs = do
           Just x  -> x ++ ":"
       args = extraArgs ++ portArg ++ [src, hostPrefix ++ dest]
   void
-    (exec' (prog ++ " " ++ unwords args) (readProcessWithExitCode prog args ""))
+    (exec' (prog ++ " " ++ unwords args) (readProcessWithExitCode prog args "") maybeRelease)
 
 ----------------------------------------------------------------------------
 -- Helpers
@@ -127,8 +134,9 @@ scp' src dest extraArgs = do
 exec' ::
      String -- ^ How to show the command in print-outs
   -> IO (ExitCode, String, String) -- ^ Handler to get (ExitCode, Output, Error) it can change accordingly to @stdout@ and @stderr@ of child process
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
   -> Hapistrano String -- ^ Raw stdout output of that program
-exec' cmd readProcessOutput = do
+exec' cmd readProcessOutput maybeRelease = do
   Config {..} <- ask
   time <- liftIO getZonedTime
   let timeStampFormat = "%T,  %F (%Z)"
@@ -146,7 +154,7 @@ exec' cmd readProcessOutput = do
   unless (null stderr') . liftIO $ configPrint StderrDest stderr'
   case exitCode' of
     ExitSuccess   -> return stdout'
-    ExitFailure n -> failWith n Nothing
+    ExitFailure n -> failWith n Nothing maybeRelease
 
 -- | Put something “inside” a line, sort-of beautifully.
 putLine :: String -> String

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -3,7 +3,7 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Juan Paucar <jpaucar@stackbuilders.com>
+-- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -22,7 +22,10 @@ module System.Hapistrano.Types
   , OutputDest(..)
   , Release
   , TargetSystem(..)
+  , DeployState(..)
   , Shell(..)
+  , Opts(..)
+  , Command(..)
   -- * Types helpers
   , mkRelease
   , releaseTime
@@ -133,11 +136,34 @@ data Release =
   Release ReleaseFormat UTCTime
   deriving (Eq, Show, Ord)
 
--- | Target's system where application will be deployed
+-- | Target's system where application will be deployed.
 data TargetSystem
   = GNULinux
   | BSD
   deriving (Eq, Show, Read, Ord, Bounded, Enum)
+
+-- | State of the deployment after running @hap deploy@.
+data DeployState
+  = Fail
+  | Success
+  deriving (Eq, Show, Read, Ord, Bounded, Enum)
+
+-- Command line options
+
+-- | Command line options.
+
+data Opts = Opts
+  { optsCommand    :: Command
+  , optsConfigFile :: FilePath
+  }
+
+-- | Command to execute and command-specific options.
+
+data Command
+  = Deploy (Maybe ReleaseFormat) (Maybe Natural) Bool -- ^ Deploy a new release (with timestamp
+    -- format and how many releases to keep)
+  | Rollback Natural -- ^ Rollback to Nth previous release
+
 
 -- | Create a 'Release' indentifier.
 mkRelease :: ReleaseFormat -> UTCTime -> Release

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -166,7 +166,8 @@ data Opts = Opts
 
 data Command
   = Deploy (Maybe ReleaseFormat) (Maybe Natural) Bool -- ^ Deploy a new release (with timestamp
-    -- format and how many releases to keep)
+    -- format, how many releases to keep, and whether the failed releases except the latest one
+    -- get deleted or not)
   | Rollback Natural -- ^ Rollback to Nth previous release
 
 

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -46,7 +46,7 @@ import Numeric.Natural
 import Path
 
 -- | Hapistrano monad.
-type Hapistrano a = ExceptT Failure (ReaderT Config IO) a
+type Hapistrano a = ExceptT (Failure, Maybe Release) (ReaderT Config IO) a
 
 -- | Failure with status code and a message.
 data Failure =

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -3,7 +3,7 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Juan Paucar <jpaucar@stackbuilders.com>
+-- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -143,9 +143,14 @@ data TargetSystem
   deriving (Eq, Show, Read, Ord, Bounded, Enum)
 
 -- | State of the deployment after running @hap deploy@.
+-- __note:__ the 'Unknown' value is not intended to be
+-- written to the @.hapistrano_deploy_state@ file; instead,
+-- it's intended to represent whenever Hapistrano couldn't
+-- get the information on the deployment state (e.g. the file is not present).
 data DeployState
   = Fail
   | Success
+  | Unknown
   deriving (Eq, Show, Read, Ord, Bounded, Enum)
 
 -- Command line options


### PR DESCRIPTION
Hi everyone. After a couple of weeks (and a lot of back and forth and many questions with @CristhianMotoche, thank you!), I have with an implementation for this feature.

This is provided both as a `hap.yaml` boolean option (`keep_one_failed`) as well as a CLI switch option (`--keep-one-failed` or just `-o`). It works as discussed in #154. One thing to note is that the old failed releases get removed before the `keep_releases` option takes place; I think it makes sense since you wouldn't want to accidentally delete failed releases first with `keep_releases` and then remove some others with `keep_one_failed`, which would also leave you with less releases than the amount you specified with `keep_releases`.

Regarding internal changes, there were a bunch of refactors, some of them in the `Main.hs` module and the `Hapistrano` monad definition, mainly regarding exception handling within `Hapistrano`. The most notable change is the removal of `ctokens`, which were previously used to tag versions as "complete". The new approach proposed in this PR is using a `.hapistrano_deploy_state` within each new release folder, containing `Success` if the deployment succeeded and `Fail` otherwise. The main advantages of this with respect to the `ctokens` approach is that we now don't have to track them separately (as they are included in the releases), and that it's now clear whether a version was deployed before or after creating this feature, in the absence of this file, whereas with `ctokens` releases without one could be either from an old version, or releases that didn't finish the build step properly.

One more thing to note here is that releases are now tagged with respect to whether they could **deploy** properly, as opposed to checking against the **build** (the way it was done with `ctokens`). I don't think this is neither right nor wrong, let me know your thoughts on this.

I haven't changed the app version in the `hapistrano.cabal` file since I'm not sure what's the etiquette on this project, or how exactly the version would change. I'm guessing it would be `0.4.3.1` -> `0.4.4.0`, since it's a minor feature, but please tell me what should I be doing on this regard.

Not sure if I'm leaving anything. Any questions or feedback is more than welcome. 😃

Solves #154.