### PR TITLE
CI now has an error message for the Haddock step when there are less than 4 modules with 100% documentation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Compile project
         run: cabal build --enable-tests
       - run: cabal test --enable-tests
-      - run: cabal haddock | grep "100%" | wc -l | grep -E "[4-9]|[1-9][0-9]+" # Fixes issue with different haddock coverage with different ghc versions https://github.com/haskell/haddock/issues/123
+      - run: |
+          # Fixes issue with different haddock coverage with different ghc versions https://github.com/haskell/haddock/issues/123
+          cabal haddock | grep "100%" | wc -l | grep -E "[4-9]|[1-9][0-9]+" ||
+          (echo "Haddock failed with exit code 1. Have you checked that the minimum of 4 modules with 100% documentation is fulfilled?" && false)
       - run: cabal sdist
       - if: matrix.ghc == '8.8.4'
         name: Login to Docker Hub


### PR DESCRIPTION
I made it so that the step, after echoing the error message, still fails with exit code 1. 

Closes #176.