### PR TITLE
Added name to Haddock step

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Compile project
         run: cabal build --enable-tests
       - run: cabal test --enable-tests
+      - name: Generate module documentation with Haddock
       - run: |
           # Fixes issue with different haddock coverage with different ghc versions https://github.com/haskell/haddock/issues/123
           cabal haddock | grep "100%" | wc -l | grep -E "[4-9]|[1-9][0-9]+" ||

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,7 +51,7 @@ jobs:
         run: cabal build --enable-tests
       - run: cabal test --enable-tests
       - name: Generate module documentation with Haddock
-      - run: |
+        run: |
           # Fixes issue with different haddock coverage with different ghc versions https://github.com/haskell/haddock/issues/123
           cabal haddock | grep "100%" | wc -l | grep -E "[4-9]|[1-9][0-9]+" ||
           (echo "Haddock failed with exit code 1. Have you checked that the minimum of 4 modules with 100% documentation is fulfilled?" && false)


### PR DESCRIPTION
The CI step involving Haddock was displaying:
> **Run # Fixes issue with different haddock coverage with different ghc versions https://github.com/haskell/haddock/issues/123**

after #176, since no name was given to the step. This PR is fixing that.