### PR TITLE
[RELEASE] Documentation changes and release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.5.0.0
+### Added
+* Ability to keep all failed releases or just one ([issue #154](https://github.com/stackbuilders/hapistrano/issues/154))
+  * Config Option: `keep_one_failed`
+  * CLI Option: `--keep-one-failed`
+
+### Modified
+* Some types and functions were modified to support the new features (e.g. `Hapistrano`, `runHapistrano`, etc.)
+
 ## 0.4.3.1
 ### Added
 * Add support for aeson 2.0

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Hackage version](https://img.shields.io/hackage/v/hapistrano.svg)](http://hackage.haskell.org/package/hapistrano)
 [![Docker Hub](https://img.shields.io/docker/build/stackbuilders/hapistrano.svg?style=flat)](https://hub.docker.com/r/stackbuilders/hapistrano)
 
-# Table of Contents - Hapistrano
+# Hapistrano
 
- * [Hapistrano](#hapistrano)
+ * [Description](#description)
  * [Purpose](#purpose)
  * [How it Works](#how-it-works)
  * [Usage](#usage)
@@ -13,11 +13,12 @@
  * [Deploying to multiple machines concurrently](#deploying-to-multiple-machines-concurrently)
  * [Docker](#docker)
  * [Nix](#nix)
+ * [Notes](#notes)
  * [License](#license)
  * [Contributing](#contributing)
 
 
-# Hapistrano
+# Description
 
 Hapistrano is a deployment library for Haskell applications similar to
 Ruby's [Capistrano](http://capistranorb.com/).
@@ -245,6 +246,10 @@ For just building Hapistrano, you just:
 ```bash
 nix-build release.nix
 ```
+
+## Notes
+
+* Hapistrano is not supported on Windows. Please check: [Issue #96](https://github.com/stackbuilders/hapistrano/issues/96).
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Hackage version](https://img.shields.io/hackage/v/hapistrano.svg)](http://hackage.haskell.org/package/hapistrano)
 [![Docker Hub](https://img.shields.io/docker/build/stackbuilders/hapistrano.svg?style=flat)](https://hub.docker.com/r/stackbuilders/hapistrano)
 
-# Table of Contents
+# Table of Contents - Hapistrano
 
  * [Hapistrano](#hapistrano)
  * [Purpose](#purpose)

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "hapistrano";
-  version = "0.4.3.1";
+  version = "0.5.0.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/example/example.cabal
+++ b/example/example.cabal
@@ -5,7 +5,7 @@ description:
   This is an example project that has been created in order to test
   the deployment process using the working_dir feature of hapistrano.
 author:         Justin Leitgeb
-maintainer:     cmotoche@stackbuilders.com
+maintainer:     hackage@stackbuilders.com
 copyright:      2015-Present Stack Builders Inc.
 license:        MIT
 license-file:   ../LICENSE

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -1,5 +1,5 @@
 name:                hapistrano
-version:             0.4.3.1
+version:             0.5.0.0
 synopsis:            A deployment library for Haskell applications
 description:
   .

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -21,7 +21,7 @@ description:
 license:             MIT
 license-file:        LICENSE
 author:              Justin Leitgeb
-maintainer:          cmotoche@stackbuilders.com
+maintainer:          hackage@stackbuilders.com
 copyright:           2015-Present Stack Builders Inc.
 category:            System
 homepage:            https://github.com/stackbuilders/hapistrano

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -3,7 +3,6 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Juan Paucar <jpaucar@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --
@@ -37,16 +36,16 @@ import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.Reader       (local, runReaderT)
 import           Data.List                  (dropWhileEnd, genericDrop, sortOn)
-import           Data.Maybe                 (mapMaybe, fromMaybe)
+import           Data.Maybe                 (fromMaybe, mapMaybe)
 import           Data.Ord                   (Down (..))
 import           Data.Time
 import           Numeric.Natural
 import           Path
 import           System.Hapistrano.Commands
+import           System.Hapistrano.Config   (deployStateFilename)
 import           System.Hapistrano.Core
 import           System.Hapistrano.Types
-import           System.Hapistrano.Config (deployStateFilename)
-import           Text.Read (readMaybe)
+import           Text.Read                  (readMaybe)
 
 ----------------------------------------------------------------------------
 
@@ -128,7 +127,7 @@ createHapistranoDeployState
   -> DeployState -- ^ Indicates how the deployment went
   -> Hapistrano ()
 createHapistranoDeployState deployPath release state = do
-  parseStatePath <- parseRelFile deployStateFilename 
+  parseStatePath <- parseRelFile deployStateFilename
   actualReleasePath <- releasePath deployPath release Nothing
   let stateFilePath = actualReleasePath </> parseStatePath
   exec (Touch stateFilePath) (Just release) -- creates '.hapistrano_deploy_state'
@@ -208,7 +207,7 @@ setupDirs deployPath = do
 ensureCacheInPlace
   :: String            -- ^ Repo URL
   -> Path Abs Dir      -- ^ Deploy path
-  -> Maybe Release     -- ^ Release that was being attempted, if it was defined 
+  -> Maybe Release     -- ^ Release that was being attempted, if it was defined
   -> Hapistrano ()
 ensureCacheInPlace repo deployPath maybeRelease = do
   let cpath = cacheRepoPath deployPath
@@ -275,7 +274,7 @@ releasesWithState selectedState deployPath = do
   where
     stateToBool :: DeployState -> Bool
     stateToBool Fail = False
-    stateToBool _ = True
+    stateToBool _    = True
 
 ----------------------------------------------------------------------------
 -- Path helpers
@@ -303,7 +302,7 @@ linkToShared
   -> Path Abs Dir -- ^ Release path
   -> Path Abs Dir -- ^ Deploy path
   -> FilePath     -- ^ Thing to link in share
-  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined
   -> Hapistrano ()
 linkToShared configTargetSystem rpath configDeployPath thingToLink maybeRelease = do
   destPath <- parseRelFile thingToLink
@@ -367,7 +366,7 @@ deployState deployPath mWorkingDir release = do
   if doesExist then do
     deployStateContents <- exec (Cat stateFilePath) (Just release)
     return $ (fromMaybe Unknown . readMaybe) deployStateContents
-  else return Unknown 
+  else return Unknown
 
 stripDirs :: Path Abs Dir -> [Path Abs t] -> Hapistrano [Path Rel t]
 stripDirs path =

--- a/src/System/Hapistrano/Commands.hs
+++ b/src/System/Hapistrano/Commands.hs
@@ -3,16 +3,15 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --
 -- Collection of type safe shell commands that can be fed into
 -- 'System.Hapistrano.Core.runCommand'.
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 module System.Hapistrano.Commands
   ( Command(..)
@@ -39,4 +38,4 @@ module System.Hapistrano.Commands
   , readScript
   ) where
 
-import System.Hapistrano.Commands.Internal
+import           System.Hapistrano.Commands.Internal

--- a/src/System/Hapistrano/Commands/Internal.hs
+++ b/src/System/Hapistrano/Commands/Internal.hs
@@ -3,7 +3,6 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --

--- a/src/System/Hapistrano/Config.hs
+++ b/src/System/Hapistrano/Config.hs
@@ -3,7 +3,6 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --
@@ -31,10 +30,8 @@ import           Data.Yaml
 import           Numeric.Natural
 import           Path
 import           System.Hapistrano.Commands
-import           System.Hapistrano.Types    (Shell(..),
-                                             ReleaseFormat (..),
-                                             Source(..),
-                                             TargetSystem (..))
+import           System.Hapistrano.Types    (ReleaseFormat (..), Shell (..),
+                                             Source (..), TargetSystem (..))
 
 -- | Hapistrano configuration typically loaded from @hap.yaml@ file.
 
@@ -54,9 +51,9 @@ data Config = Config
     -- ^ Collection of files to copy over to target machine before building
   , configCopyDirs       :: ![CopyThing]
     -- ^ Collection of directories to copy over to target machine before building
-  , configLinkedFiles      :: ![FilePath]
+  , configLinkedFiles    :: ![FilePath]
     -- ^ Collection of files to link from each release to _shared_
-  , configLinkedDirs       :: ![FilePath]
+  , configLinkedDirs     :: ![FilePath]
     -- ^ Collection of directories to link from each release to _shared_
   , configVcAction       :: !Bool
   -- ^ Perform version control related actions. By default, it's assumed to be `True`.
@@ -74,13 +71,13 @@ data Config = Config
   -- ^ The number of releases to keep, the @--keep-releases@ argument passed via
   -- the CLI takes precedence over this value. If neither CLI or configuration
   -- file value is specified, it defaults to 5
-  , configKeepOneFailed :: !Bool
+  , configKeepOneFailed  :: !Bool
   -- ^ Specifies whether to keep all failed releases along with the successful releases
   -- or just the latest failed (at least this one should be kept for debugging purposes).
   -- The @--keep-one-failed@ argument passed via the CLI takes precedence over this value.
-  -- If neither CLI or configuration file value is specified, it defaults to `False` 
+  -- If neither CLI or configuration file value is specified, it defaults to `False`
   -- (i.e. keep all failed releases).
-  , configWorkingDir :: !(Maybe (Path Rel Dir))
+  , configWorkingDir     :: !(Maybe (Path Rel Dir))
   } deriving (Eq, Ord, Show)
 
 -- | Information about source and destination locations of a file\/directory
@@ -156,8 +153,8 @@ mkCmd raw =
     Nothing  -> fail "invalid restart command"
     Just cmd -> return cmd
 
--- | Constant with the name of the file used to store 
+-- | Constant with the name of the file used to store
 -- the deployment state information.
 
-deployStateFilename :: String 
+deployStateFilename :: String
 deployStateFilename = ".hapistrano_deploy_state"

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -3,7 +3,6 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --
@@ -31,7 +30,7 @@ import           Path
 import           System.Console.ANSI
 import           System.Exit
 import           System.Hapistrano.Commands
-import           System.Hapistrano.Types hiding (Command)
+import           System.Hapistrano.Types    hiding (Command)
 import           System.Process
 import           System.Process.Typed       (ProcessConfig)
 import qualified System.Process.Typed       as SPT
@@ -50,7 +49,7 @@ failWith n msg maybeRelease = throwError (Failure n msg, maybeRelease)
 exec ::
      forall a. Command a
   => a -- ^ Command being executed
-  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined
   -> Hapistrano (Result a)
 exec typedCmd maybeRelease = do
   let cmd = renderCommand typedCmd
@@ -60,9 +59,9 @@ exec typedCmd maybeRelease = do
 
 -- | Same as 'exec' but it streams to stdout only for _GenericCommand_s
 execWithInheritStdout ::
-     Command a 
+     Command a
   => a -- ^ Command being executed
-  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined
   -> Hapistrano ()
 execWithInheritStdout typedCmd maybeRelease = do
   let cmd = renderCommand typedCmd
@@ -100,7 +99,7 @@ getProgAndArgs cmd = do
 scpFile ::
      Path Abs File -- ^ Location of the file to copy
   -> Path Abs File -- ^ Where to put the file on target machine
-  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined
   -> Hapistrano ()
 scpFile src dest = scp' (fromAbsFile src) (fromAbsFile dest) ["-q"]
 
@@ -108,7 +107,7 @@ scpFile src dest = scp' (fromAbsFile src) (fromAbsFile dest) ["-q"]
 scpDir ::
      Path Abs Dir -- ^ Location of the directory to copy
   -> Path Abs Dir -- ^ Where to put the dir on target machine
-  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined
   -> Hapistrano ()
 scpDir src dest = scp' (fromAbsDir src) (fromAbsDir dest) ["-qr"]
 
@@ -134,7 +133,7 @@ scp' src dest extraArgs maybeRelease = do
 exec' ::
      String -- ^ How to show the command in print-outs
   -> IO (ExitCode, String, String) -- ^ Handler to get (ExitCode, Output, Error) it can change accordingly to @stdout@ and @stderr@ of child process
-  -> Maybe Release -- ^ Release that was being attempted, if it was defined 
+  -> Maybe Release -- ^ Release that was being attempted, if it was defined
   -> Hapistrano String -- ^ Raw stdout output of that program
 exec' cmd readProcessOutput maybeRelease = do
   Config {..} <- ask

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -3,13 +3,12 @@
 -- Copyright   :  © 2015-Present Stack Builders
 -- License     :  MIT
 --
--- Maintainer  :  Cristhian Motoche <cmotoche@stackbuilders.com>
 -- Stability   :  experimental
 -- Portability :  portable
 --
 -- Type definitions for the Hapistrano tool.
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
 
 module System.Hapistrano.Types
   ( Hapistrano
@@ -36,14 +35,14 @@ module System.Hapistrano.Types
   , toMaybePath
   ) where
 
-import Control.Applicative
-import Control.Monad.Except
-import Control.Monad.Reader
-import Data.Aeson
-import Data.Maybe
-import Data.Time
-import Numeric.Natural
-import Path
+import           Control.Applicative
+import           Control.Monad.Except
+import           Control.Monad.Reader
+import           Data.Aeson
+import           Data.Maybe
+import           Data.Time
+import           Numeric.Natural
+import           Path
 
 -- | Hapistrano monad.
 type Hapistrano a = ExceptT (Failure, Maybe Release) (ReaderT Config IO) a
@@ -55,11 +54,11 @@ data Failure =
 -- | Hapistrano configuration options.
 data Config =
   Config
-    { configSshOptions :: !(Maybe SshOptions)
+    { configSshOptions   :: !(Maybe SshOptions)
     -- ^ 'Nothing' if we are running locally, or SSH options to use.
     , configShellOptions :: !Shell
     -- ^ One of the supported 'Shell's
-    , configPrint :: !(OutputDest -> String -> IO ())
+    , configPrint        :: !(OutputDest -> String -> IO ())
     -- ^ How to print messages
     }
 
@@ -67,7 +66,7 @@ data Config =
 -- like GitHub or a local directory.
 data Source
   = GitRepository
-      { gitRepositoryURL :: String
+      { gitRepositoryURL      :: String
       -- ^ The URL of remote Git repository to deploy
       , gitRepositoryRevision :: String
       -- ^ The SHA1 or branch to release
@@ -81,9 +80,9 @@ data Source
 -- | The records describes deployment task.
 data Task =
   Task
-    { taskDeployPath :: Path Abs Dir
+    { taskDeployPath    :: Path Abs Dir
     -- ^ The root of the deploy target on the remote host
-    , taskSource :: Source
+    , taskSource        :: Source
     -- ^ The 'Source' to deploy
     , taskReleaseFormat :: ReleaseFormat
     -- ^ The 'ReleaseFormat' to use
@@ -186,7 +185,7 @@ renderRelease (Release rfmt time) = formatTime defaultTimeLocale fmt time
     fmt =
       case rfmt of
         ReleaseShort -> releaseFormatShort
-        ReleaseLong -> releaseFormatLong
+        ReleaseLong  -> releaseFormatLong
 
 ----------------------------------------------------------------------------
 -- Types helpers


### PR DESCRIPTION
# Changes
- Avoid 'Table of Contents' in first title to avoid hackage styling issue
  - Haddock adds an `id` to the titles parsed from the README.md
  - [table-of-contents](https://github.com/haskell/haddock/blob/4411b41aee79fa6365773e4660ca8e3acc6a5b32/haddock-api/resources/html/Linuwial.std-theme/linuwial.css#L80-L87) has some specific styles
- Change titles and add notes for Windows
- Change maintainer and remove it from modules
  - I changed the maintainer's email in the cabal file
  - I removed the maintainer from the package modules
- Prepare release (v0.5.0.0) since it contains breaking changes. Includes:
  - #174
  - #183 
  - Documentation changes in this PR 
