### PR TITLE
Move md files to extra-doc-files block

### DIFF
--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -1,3 +1,4 @@
+cabal-version:       1.18
 name:                hapistrano
 version:             0.4.3.1
 synopsis:            A deployment library for Haskell applications
@@ -27,9 +28,8 @@ category:            System
 homepage:            https://github.com/stackbuilders/hapistrano
 bug-reports:         https://github.com/stackbuilders/hapistrano/issues
 build-type:          Simple
-cabal-version:       >=1.18
 tested-with:         GHC==8.10.17, GHC==9.0.2
-extra-source-files:  CHANGELOG.md
+extra-doc-files:     CHANGELOG.md
                    , README.md
 
 flag dev


### PR DESCRIPTION
Prevents recompilations caused by changes to the `.md` files

```
Run cabal build
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - hapistrano-0.[4](https://github.com/stackbuilders/hapistrano/runs/5978860261?check_suite_focus=true#step:10:4).3.1 (lib) (file README.md changed)
 - hapistrano-0.4.3.1 (test:test) (dependency rebuilt)
 - hapistrano-0.4.3.1 (exe:hap) (dependency rebuilt)
 ```
 
 **Note**
 
 Credits to @jpvillaisaza for suggesting this change.