### PR TITLE
[FIX] Change version to 0.4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0.0
+## 0.4.4.0
 ### Added
 * Ability to keep all failed releases or just one ([issue #154](https://github.com/stackbuilders/hapistrano/issues/154))
   * Config Option: `keep_one_failed`

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "hapistrano";
-  version = "0.5.0.0";
+  version = "0.4.4.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.18
 name:                hapistrano
-version:             0.5.0.0
+version:             0.4.4.0
 synopsis:            A deployment library for Haskell applications
 description:
   .


### PR DESCRIPTION
# Changes

Hapistrano is mainly used as a CLI and its CLI didn't change to request mandatory
field or flags. Therefore, I changed the next version to `0.4.4.0`.
