### PR TITLE
Define Hapistrano with Deriving Via strategy

### DIFF
--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -63,6 +63,7 @@ library
                      , typed-process      >= 0.2 && < 0.3
                      , time               >= 1.5 && < 1.11
                      , transformers       >= 0.4 && < 0.6
+                     , exceptions         >= 0.10 && < 0.11
                      , yaml               >= 0.11.7 && < 0.12
   if flag(dev)
     ghc-options:       -Wall -Werror

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -66,7 +66,7 @@ runHapistrano sshOptions shell' printFnc m =
             , configShellOptions = shell'
             , configPrint = printFnc
             }
-    r <- runReaderT (runExceptT m) config
+    r <- unHapistrano m config
     case r of
       Left (Failure n msg, _) -> do
         forM_ msg (printFnc StderrDest)

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -35,6 +35,30 @@ import           System.Process
 import           System.Process.Typed       (ProcessConfig)
 import qualified System.Process.Typed       as SPT
 
+-- | Run the 'Hapistrano' monad. The monad hosts 'exec' actions.
+runHapistrano ::
+     MonadIO m
+  => Maybe SshOptions -- ^ SSH options to use or 'Nothing' if we run locally
+  -> Shell -- ^ Shell to run commands
+  -> (OutputDest -> String -> IO ()) -- ^ How to print messages
+  -> Hapistrano a -- ^ The computation to run
+  -> m (Either Int a) -- ^ Status code in 'Left' on failure, result in
+              -- 'Right' on success
+runHapistrano sshOptions shell' printFnc m =
+  liftIO $ do
+    let config =
+          Config
+            { configSshOptions = sshOptions
+            , configShellOptions = shell'
+            , configPrint = printFnc
+            }
+    r <- unHapistrano m config
+    case r of
+      Left (Failure n msg) -> do
+        forM_ msg (printFnc StderrDest)
+        return (Left n)
+      Right x -> return (Right x)
+
 -- | Fail returning the following status code and message.
 failWith :: Int -> Maybe String -> Maybe Release -> Hapistrano a
 failWith n msg maybeRelease = throwError (Failure n msg, maybeRelease)

--- a/src/System/Hapistrano/Core.hs
+++ b/src/System/Hapistrano/Core.hs
@@ -54,7 +54,7 @@ runHapistrano sshOptions shell' printFnc m =
             }
     r <- unHapistrano m config
     case r of
-      Left (Failure n msg) -> do
+      Left (Failure n msg, _) -> do
         forM_ msg (printFnc StderrDest)
         return (Left n)
       Right x -> return (Right x)

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -49,8 +49,19 @@ import           Numeric.Natural
 import           Path
 
 -- | Hapistrano monad.
-newtype Hapistrano a = Hapistrano {unHapistrano :: Config -> IO (Either Failure a)}
-  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadReader Config, MonadError Failure) via (ExceptT Failure (ReaderT Config IO))
+newtype Hapistrano a =
+  Hapistrano { unHapistrano :: Config -> IO (Either (Failure, Maybe Release) a) }
+    deriving
+      ( Functor
+      , Applicative
+      , Monad
+      , MonadIO
+      , MonadThrow
+      , MonadCatch
+      , MonadMask
+      , MonadReader Config
+      , MonadError (Failure, Maybe Release)
+      ) via (ExceptT (Failure, Maybe Release) (ReaderT Config IO))
 
 -- | Failure with status code and a message.
 data Failure =

--- a/src/System/Hapistrano/Types.hs
+++ b/src/System/Hapistrano/Types.hs
@@ -7,11 +7,12 @@
 -- Portability :  portable
 --
 -- Type definitions for the Hapistrano tool.
+{-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module System.Hapistrano.Types
-  ( Hapistrano
+  ( Hapistrano(..)
   , Failure(..)
   , Config(..)
   , Source(..)
@@ -37,6 +38,8 @@ module System.Hapistrano.Types
   ) where
 
 import           Control.Applicative
+import           Control.Monad.Catch
+import           Control.Monad.Error.Class
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Data.Aeson
@@ -46,7 +49,8 @@ import           Numeric.Natural
 import           Path
 
 -- | Hapistrano monad.
-type Hapistrano a = ExceptT (Failure, Maybe Release) (ReaderT Config IO) a
+newtype Hapistrano a = Hapistrano {unHapistrano :: Config -> IO (Either Failure a)}
+  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadReader Config, MonadError Failure) via (ExceptT Failure (ReaderT Config IO))
 
 -- | Failure with status code and a message.
 data Failure =


### PR DESCRIPTION
## Changes:
- Define `Hapistrano` as a `newtype`
- Use `Deriving Via` to get the needed instances