### PR TITLE
[NO ISSUE] Refactoring: Move Deploy task into library

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -135,17 +135,11 @@ main = do
         r <- Hap.runHapistrano sshOpts shell printFnc $
           case optsCommand of
             Deploy cliReleaseFormat cliKeepReleases cliKeepOneFailed ->
-              let releaseFormat = fromMaybeReleaseFormat cliReleaseFormat configReleaseFormat
-                  keepReleases = fromMaybeKeepReleases cliKeepReleases configKeepReleases
-                  keepOneFailed = cliKeepOneFailed || configKeepOneFailed
-                  task =
-                    Task
-                    { taskDeployPath    = configDeployPath
-                    , taskSource        = configSource
-                    , taskReleaseFormat = releaseFormat
-                    }
-              in
-                Hap.deploy hapConfig task keepReleases keepOneFailed
+              Hap.deploy
+                hapConfig
+                (fromMaybeReleaseFormat cliReleaseFormat configReleaseFormat)
+                (fromMaybeKeepReleases cliKeepReleases configKeepReleases)
+                (cliKeepOneFailed || configKeepOneFailed)
             Rollback n ->
               Hap.rollback configTargetSystem configDeployPath n configRestartCommand
             Maintenance Enable-> do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -180,9 +180,8 @@ main = do
                 Hap.createHapistranoDeployState configDeployPath release System.Hapistrano.Types.Success
                 Hap.dropOldReleases configDeployPath keepReleases keepOneFailed
               `catch` failStateAndThrow
-            Rollback n -> do
-              Hap.rollback configTargetSystem configDeployPath n
-              forM_ configRestartCommand (flip Hap.exec Nothing)
+            Rollback n ->
+              Hap.rollback configTargetSystem configDeployPath n configRestartCommand
             Maintenance Enable-> do
               Hap.writeMaintenanceFile configDeployPath configMaintenanceDirectory configMaintenanceFileName
             Maintenance _ -> do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,21 +11,15 @@ import           Control.Monad
 #if !MIN_VERSION_base(4,13,0)
 import           Data.Monoid                   ((<>))
 #endif
-import           Control.Monad.Catch           (catch, throwM)
 import           Data.Version                  (showVersion)
 import qualified Data.Yaml.Config              as Yaml
 import           Development.GitRev
 import           Formatting                    (formatToString, string, (%))
 import           Options.Applicative           hiding (str)
-import           Path
-import           Path.IO
 import           Paths_hapistrano              (version)
 import           System.Exit
-import           System.Hapistrano             (createHapistranoDeployState)
 import qualified System.Hapistrano             as Hap
-import qualified System.Hapistrano.Commands    as Hap
 import qualified System.Hapistrano.Config      as C
-import qualified System.Hapistrano.Core        as Hap
 import qualified System.Hapistrano.Maintenance as Hap
 import           System.Hapistrano.Types
 import           System.IO

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -127,11 +127,8 @@ data Message
 main :: IO ()
 main = do
   Opts{..} <- execParser parserInfo
-  C.Config{..} <- Yaml.loadYamlSettings [optsConfigFile] [] Yaml.useEnv
+  hapConfig@C.Config{..} <- Yaml.loadYamlSettings [optsConfigFile] [] Yaml.useEnv
   chan <- newTChanIO
-  let task rf = Task { taskDeployPath    = configDeployPath
-                     , taskSource        = configSource
-                     , taskReleaseFormat = rf }
   let printFnc dest str = atomically $
         writeTChan chan (PrintMsg dest str)
       hap shell sshOpts = do
@@ -141,45 +138,14 @@ main = do
               let releaseFormat = fromMaybeReleaseFormat cliReleaseFormat configReleaseFormat
                   keepReleases = fromMaybeKeepReleases cliKeepReleases configKeepReleases
                   keepOneFailed = cliKeepOneFailed || configKeepOneFailed
-                  -- We define the handler for when an exception happens inside a deployment
-                  failStateAndThrow e@(HapistranoException (_, maybeRelease)) = do
-                    case maybeRelease of
-                      (Just release) -> do
-                        createHapistranoDeployState configDeployPath release Fail
-                        Hap.dropOldReleases configDeployPath keepReleases keepOneFailed
-                        throwM e
-                      Nothing -> do
-                        throwM e
-              in do
-                forM_ configRunLocally Hap.playScriptLocally
-                release <- if configVcAction
-                            then Hap.pushRelease (task releaseFormat)
-                            else Hap.pushReleaseWithoutVc (task releaseFormat)
-                rpath <- Hap.releasePath configDeployPath release configWorkingDir
-                forM_ (toMaybePath configSource) $ \src ->
-                  Hap.scpDir src rpath (Just release)
-                forM_ configCopyFiles $ \(C.CopyThing src dest) -> do
-                  srcPath  <- resolveFile' src
-                  destPath <- parseRelFile dest
-                  let dpath = rpath </> destPath
-                  (flip Hap.exec (Just release) . Hap.MkDir . parent) dpath
-                  Hap.scpFile srcPath dpath (Just release)
-                forM_ configCopyDirs $ \(C.CopyThing src dest) -> do
-                  srcPath  <- resolveDir' src
-                  destPath <- parseRelDir dest
-                  let dpath = rpath </> destPath
-                  (flip Hap.exec (Just release) . Hap.MkDir . parent) dpath
-                  Hap.scpDir srcPath dpath (Just release)
-                forM_ configLinkedFiles
-                  $ flip (Hap.linkToShared configTargetSystem rpath configDeployPath) (Just release)
-                forM_ configLinkedDirs
-                  $ flip (Hap.linkToShared configTargetSystem rpath configDeployPath) (Just release)
-                forM_ configBuildScript (Hap.playScript configDeployPath release configWorkingDir)
-                Hap.activateRelease configTargetSystem configDeployPath release
-                forM_ configRestartCommand (flip Hap.exec $ Just release)
-                Hap.createHapistranoDeployState configDeployPath release System.Hapistrano.Types.Success
-                Hap.dropOldReleases configDeployPath keepReleases keepOneFailed
-              `catch` failStateAndThrow
+                  task =
+                    Task
+                    { taskDeployPath    = configDeployPath
+                    , taskSource        = configSource
+                    , taskReleaseFormat = releaseFormat
+                    }
+              in
+                Hap.deploy hapConfig task keepReleases keepOneFailed
             Rollback n ->
               Hap.rollback configTargetSystem configDeployPath n configRestartCommand
             Maintenance Enable-> do

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -59,6 +59,7 @@ library
                      , mtl                >= 2.0 && < 3.0
                      , stm                >= 2.0 && < 2.6
                      , path               >= 0.5 && < 0.9
+                     , path-io            >= 1.2 && < 1.7
                      , process            >= 1.4 && < 1.7
                      , typed-process      >= 0.2 && < 0.3
                      , time               >= 1.5 && < 1.11
@@ -85,7 +86,7 @@ executable hap
                      , mtl                >= 2.0 && < 3.0
                      , optparse-applicative >= 0.11 && < 0.17
                      , path               >= 0.5 && < 0.9
-                     , path-io            >= 1.2 && < 1.7
+                     , path-io
                      , stm                >= 2.4 && < 2.6
                      , yaml               >= 0.11.7 && < 0.12
   if flag(dev)

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -76,17 +76,12 @@ executable hap
   hs-source-dirs:      app
   main-is:             Main.hs
   other-modules:       Paths_hapistrano
-  build-depends:       aeson              >= 2.0 && < 3.0
-                     , async              >= 2.0.1.6 && < 2.4
+  build-depends:       async              >= 2.0.1.6 && < 2.4
                      , base               >= 4.9 && < 5.0
-                     , exceptions
                      , formatting         >= 6.2 && < 8.0
                      , gitrev             >= 1.2 && < 1.4
                      , hapistrano
-                     , mtl                >= 2.0 && < 3.0
                      , optparse-applicative >= 0.11 && < 0.17
-                     , path               >= 0.5 && < 0.9
-                     , path-io
                      , stm                >= 2.4 && < 2.6
                      , yaml               >= 0.11.7 && < 0.12
   if flag(dev)

--- a/spec/System/HapistranoSpec.hs
+++ b/spec/System/HapistranoSpec.hs
@@ -247,8 +247,9 @@ spec = do
       it "resets the ‘current’ symlink correctly" $ \(deployPath, repoPath) ->
         runHap $ do
           let task = mkTask deployPath repoPath
+              noCmd = Nothing
           rs <- replicateM 5 (Hap.pushRelease task)
-          Hap.rollback currentSystem deployPath 2
+          Hap.rollback currentSystem deployPath 2 noCmd
           rpath <- Hap.releasePath deployPath (rs !! 2) Nothing
           let rc :: Hap.Readlink Dir
               rc =

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -140,9 +140,14 @@ createHapistranoDeployState deployPath release state = do
   exec (Touch stateFilePath) (Just release) -- creates '.hapistrano_deploy_state'
   exec (BasicWrite stateFilePath $ show state) (Just release) -- writes the deploy state to '.hapistrano_deploy_state'
 
--- | Deploys!
-deploy :: HC.Config -> Task -> Natural -> Bool -> Hapistrano ()
-deploy HC.Config{..} task keepReleases keepOneFailed = do
+-- | Deploys a new release
+deploy
+  :: HC.Config -- ^ Deploy configuration
+  -> ReleaseFormat -- ^ Long or Short format
+  -> Natural -- ^ Number of releases to keep
+  -> Bool -- ^ Wheter we should keep one failed release or not
+  -> Hapistrano ()
+deploy HC.Config{..} releaseFormat keepReleases keepOneFailed = do
   forM_ configRunLocally playScriptLocally
   release <- if configVcAction
               then pushRelease task
@@ -181,6 +186,12 @@ deploy HC.Config{..} task keepReleases keepOneFailed = do
           throwM e
         Nothing -> do
           throwM e
+    task =
+      Task
+      { taskDeployPath    = configDeployPath
+      , taskSource        = configSource
+      , taskReleaseFormat = releaseFormat
+      }
 
 -- | Activates one of already deployed releases.
 

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -142,12 +142,14 @@ rollback
   :: TargetSystem
   -> Path Abs Dir      -- ^ Deploy path
   -> Natural           -- ^ How many releases back to go, 0 re-activates current
+  -> Maybe GenericCommand -- ^ Restart command
   -> Hapistrano ()
-rollback ts deployPath n = do
+rollback ts deployPath n mbRestartCommand = do
   releases <- releasesWithState Success deployPath
   case genericDrop n releases of
     [] -> failWith 1 (Just "Could not find the requested release to rollback to.") Nothing
     (x:_) -> activateRelease ts deployPath x
+  forM_ mbRestartCommand (`exec` Nothing)
 
 -- | Remove older releases to avoid filling up the target host filesystem.
 

--- a/src/System/Hapistrano.hs
+++ b/src/System/Hapistrano.hs
@@ -21,6 +21,7 @@ module System.Hapistrano
   , activateRelease
   , linkToShared
   , createHapistranoDeployState
+  , deploy
   , rollback
   , dropOldReleases
   , playScript
@@ -35,7 +36,7 @@ where
 
 import           Control.Exception          (try)
 import           Control.Monad
-import           Control.Monad.Catch        (catch)
+import           Control.Monad.Catch        (catch, throwM)
 import           Control.Monad.Except
 import           Control.Monad.Reader       (local)
 import           Data.List                  (dropWhileEnd, genericDrop, sortOn)
@@ -44,8 +45,11 @@ import           Data.Ord                   (Down (..))
 import           Data.Time
 import           Numeric.Natural
 import           Path
+import           Path.IO
 import           System.Hapistrano.Commands
-import           System.Hapistrano.Config   (deployStateFilename)
+import           System.Hapistrano.Config   (CopyThing (..),
+                                             deployStateFilename)
+import qualified System.Hapistrano.Config   as HC
 import           System.Hapistrano.Core
 import           System.Hapistrano.Types
 import           Text.Read                  (readMaybe)
@@ -135,6 +139,48 @@ createHapistranoDeployState deployPath release state = do
   let stateFilePath = actualReleasePath </> parseStatePath
   exec (Touch stateFilePath) (Just release) -- creates '.hapistrano_deploy_state'
   exec (BasicWrite stateFilePath $ show state) (Just release) -- writes the deploy state to '.hapistrano_deploy_state'
+
+-- | Deploys!
+deploy :: HC.Config -> Task -> Natural -> Bool -> Hapistrano ()
+deploy HC.Config{..} task keepReleases keepOneFailed = do
+  forM_ configRunLocally playScriptLocally
+  release <- if configVcAction
+              then pushRelease task
+              else pushReleaseWithoutVc task
+  rpath <- releasePath configDeployPath release configWorkingDir
+  forM_ (toMaybePath configSource) $ \src ->
+    scpDir src rpath (Just release)
+  forM_ configCopyFiles $ \(CopyThing src dest) -> do
+    srcPath  <- resolveFile' src
+    destPath <- parseRelFile dest
+    let dpath = rpath </> destPath
+    (flip exec (Just release) . MkDir . parent) dpath
+    scpFile srcPath dpath (Just release)
+  forM_ configCopyDirs $ \(CopyThing src dest) -> do
+    srcPath  <- resolveDir' src
+    destPath <- parseRelDir dest
+    let dpath = rpath </> destPath
+    (flip exec (Just release) . MkDir . parent) dpath
+    scpDir srcPath dpath (Just release)
+  forM_ configLinkedFiles
+    $ flip (linkToShared configTargetSystem rpath configDeployPath) (Just release)
+  forM_ configLinkedDirs
+    $ flip (linkToShared configTargetSystem rpath configDeployPath) (Just release)
+  forM_ configBuildScript (playScript configDeployPath release configWorkingDir)
+  activateRelease configTargetSystem configDeployPath release
+  forM_ configRestartCommand (flip exec $ Just release)
+  createHapistranoDeployState configDeployPath release Success
+  dropOldReleases configDeployPath keepReleases keepOneFailed
+  `catch` failStateAndThrow
+    where
+    failStateAndThrow e@(HapistranoException (_, maybeRelease)) = do
+      case maybeRelease of
+        (Just release) -> do
+          createHapistranoDeployState configDeployPath release Fail
+          dropOldReleases configDeployPath keepReleases keepOneFailed
+          throwM e
+        Nothing -> do
+          throwM e
 
 -- | Activates one of already deployed releases.
 


### PR DESCRIPTION
### Changes
- Include restart command call inside rollback function
- Abstract deploy command into a new function

### How is this useful?
- This will help to test `deploy` easily since it has been extracted from `app/Main`
- Main becomes easier to read since the Command type constructor take us to the appropriate functions