### PR TITLE
Update Docker file for distroless base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,7 @@ COPY . .
 RUN cabal build --enable-executable-static && \
     cp $(cabal exec which hap) hap
 
-FROM alpine:3.15
-MAINTAINER Nicolas Vivar <nvivar@stackbuilders.com>
-RUN apk update && \
-    apk add \
-      ca-certificates \
-      git \
-      openssh-client
-RUN mkdir ~/.ssh
+FROM gcr.io/distroless/static-debian11
+LABEL maintainer="Nicolas Vivar <nvivar@stackbuilders.com>"
 COPY --from=build /usr/src/app/hap /usr/local/bin/hap
 ENTRYPOINT ["/usr/local/bin/hap"]
-CMD ["--help"]


### PR DESCRIPTION
Updates docker file to use a light distribution base for hapistrano as requested on #182.

