### PR TITLE
Increate timeout for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           - ghc902
       fail-fast: true
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v12


### PR DESCRIPTION
Current binary caches for GHC don't have ghc902 pacakges for dependencies, and therefore have to be recreated with every build. We could consider a cachix for ourselves to host these, but increasing the timeout should suffice for now, specially since CI minutes are not charged for a public repo.

Fixes https://github.com/stackbuilders/hapistrano/issues/242