### PR TITLE
Simplification of Nix flake and removal of GHC 8

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ jobs:
           - macos-13      # x86_64-darwin
           - macos-latest  # aarch64-darwin
           - ubuntu-latest # x86_64-linux
-        ghc:
-          - ghc966
       fail-fast: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -27,9 +25,9 @@ jobs:
           extra-conf: accept-flake-config = true
       - uses: DeterminateSystems/magic-nix-cache-action@v7
       - name: Compile code ${{ matrix.ghc }}
-        run: nix build .#test-${{ matrix.ghc }}
+        run: nix build .#test
       - name: Run tests ${{ matrix.ghc }}
-        run: nix run .#test-${{ matrix.ghc }}
+        run: nix run .#test
 
   docker:
     uses: ./.github/workflows/reusable-docker.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,7 @@ jobs:
           - macos-latest  # aarch64-darwin
           - ubuntu-latest # x86_64-linux
         ghc:
-          - ghc8107
-          - ghc902
+          - ghc96
       fail-fast: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           - macos-latest  # aarch64-darwin
           - ubuntu-latest # x86_64-linux
         ghc:
-          - ghc96
+          - ghc966
       fail-fast: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.o
 .cabal-sandbox/
 .direnv/
-.envrc
 .hpc
 .hsenv
 .tool-versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM utdemir/ghc-musl:v24-ghc96 AS build
+FROM quay.io/benz0li/ghc-musl:9.6.6 AS build
 WORKDIR /usr/src/app
 COPY hapistrano.cabal .
 RUN cabal update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM utdemir/ghc-musl:v24-ghc902 AS build
+FROM utdemir/ghc-musl:v24-ghc96 AS build
 WORKDIR /usr/src/app
 COPY hapistrano.cabal .
 RUN cabal update && \
@@ -8,7 +8,7 @@ RUN cabal build --enable-executable-static && \
     cp $(cabal exec which hap) hap
 
 FROM alpine:3.15
-MAINTAINER Nicolas Vivar <nvivar@stackbuilders.com>
+MAINTAINER Cristhian Motoche <cmotoche@stackbuilders.com>
 RUN apk update && \
     apk add \
       ca-certificates \

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -22,40 +22,27 @@ sudo launchctl start org.nixos.nix-daemon
 ```
 
 If the following messages appear running the scripts detailed in the section
-below, it means that the Nix is not able to talk with the cache, in which case
-is recommended to go over the steps detailed in this section again:
+below, it means that Nix is not picking up the substituters we described
+earlier and is unable to use them as a derivation cache: 
 
 ```
 warning: ignoring untrusted substituter 'https://cache.iog.io'
 ```
+in which case
+it is recommended to go over the steps detailed in this section again, or look for alternative ways to add extra substituters in [nix.conf](https://nix.dev/manual/nix/2.18/command-ref/conf-file).
 
-## Switching between different GHC versions
+## Enabling the development environment
 
-The `bin` directory, holds all available shells:
-
-```
-ls bin | grep ghc
-```
-
-To spawn a new shell with a pre-defined GHC version, choose one of the scripts
-listed above and run the following command:
-
-```sh
-./bin/ghc90
-```
-
-Once inside the shell, verify the GHC version matches the script name:
+To enable the development environment exposed by the project's [Nix flake](../flake.nix), you can start a development shell by running the following command from within the project's root:
 
 ```
-ghc --version
+nix develop
 ```
 
-After that, all commands detailed in the [Getting
-Started](../README.md#getting-started) section should work the same.
+Alternatively, if you are using [nix-direnv](https://github.com/nix-community/nix-direnv) (recommended), you can run:
 
-Alternatively, to run a command without spawning a new shell use the `-c`
-option:
-
-```sh
-./bin/ghc90 -c <command>
 ```
+direnv allow
+```
+
+that will enable the development shell according to the contents of [.envrc](../.envrc). It is advisable not to run `direnv allow` blindly and always check the contents of [.envrc](../.envrc) files first to ensure nothing malicious is executed.

--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -135,51 +135,14 @@
         "type": "github"
       }
     },
-    "ghc910X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714520650,
-        "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
-        "ref": "ghc-9.10",
-        "rev": "2c6375b9a804ac7fca1e82eb6fcfc8594c67c5f5",
-        "revCount": 62663,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.10",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc911": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714817013,
-        "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
-        "ref": "refs/heads/master",
-        "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
-        "revCount": 62816,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1719016632,
-        "narHash": "sha256-SVZYZg2/9LasyfijTiY/dgr3g7v3BRRx0yyxtDnsLE8=",
+        "lastModified": 1727656118,
+        "narHash": "sha256-RwerqkdfQIP2IsVbRmuYbb+eogm6S9Bk1CO49shkGVs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "7a26dca8c822a23a4e5a725ccd56da11b0dd74de",
+        "rev": "b9ffc606875b2ccf24a08a1dc84419a6a9eb5d9b",
         "type": "github"
       },
       "original": {
@@ -197,8 +160,6 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "ghc910X": "ghc910X",
-        "ghc911": "ghc911",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
@@ -209,6 +170,7 @@
         "hls-2.6": "hls-2.6",
         "hls-2.7": "hls-2.7",
         "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -223,16 +185,17 @@
         "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1719017430,
-        "narHash": "sha256-n/ctlEhmzGcco5hXM+OWimkr1XqKyjHXt9wSv88HyqI=",
+        "lastModified": 1727657466,
+        "narHash": "sha256-aOHI5E0PcihXlwQQgcSiLsIrk4sYg4SI+zxpFO34lC8=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "f65f0349733b0c18139a960bf1ce95d18589c917",
+        "rev": "a4fc7302dec23f5ae2064b90b19090067be1550e",
         "type": "github"
       },
       "original": {
@@ -390,6 +353,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1720003792,
+        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -585,11 +565,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
         "type": "github"
       },
       "original": {
@@ -601,16 +581,32 @@
     },
     "nixpkgs-2311": {
       "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1720122915,
+        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -633,17 +629,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
+        "lastModified": 1720181791,
+        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
+        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -677,11 +673,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1719015795,
-        "narHash": "sha256-wJyFaY7m75xH3CIHPxJ25H+nE7BdtDOxF6JLyAaSvWk=",
+        "lastModified": 1727655087,
+        "narHash": "sha256-t+mvlQp15og02vGhehBR5Amv3r+eTMJ7IE3BdpqmPVo=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "56a010491be669780a5edf06445bd3f81e05b165",
+        "rev": "08a17b45866f3de7bbd083677ea28b56c74cd1f3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,13 @@
                   name = "hapistrano";
                   src = ./.;
                 };
+                # This is used by `nix develop .` to open a shell for use with
+                # `cabal`, `hlint` and `haskell-language-server`
+                shell.tools = {
+                  cabal = {};
+                  hlint = {};
+                  haskell-language-server = {};
+                };
                 compiler-nix-name = "ghc96";
               };
             })

--- a/flake.nix
+++ b/flake.nix
@@ -27,51 +27,27 @@
           overlays = [
             haskellNix.overlay
             (final: prev: {
-              hapistrano-ghc8107 = final.haskell-nix.cabalProject' {
+              hapistrano-ghc96 = final.haskell-nix.cabalProject' {
                 src = final.haskell-nix.haskellLib.cleanGit {
                   name = "hapistrano";
                   src = ./.;
                 };
-                compiler-nix-name = "ghc8107";
-              };
-              hapistrano-ghc902 = final.haskell-nix.cabalProject' {
-                src = final.haskell-nix.haskellLib.cleanGit {
-                  name = "hapistrano";
-                  src = ./.;
-                };
-                compiler-nix-name = "ghc902";
+                compiler-nix-name = "ghc96";
               };
             })
           ];
         };
-        flake-ghc8107 = pkgs.hapistrano-ghc8107.flake { };
-        flake-ghc902 = pkgs.hapistrano-ghc902.flake { };
+        flake-ghc96 = pkgs.hapistrano-ghc96.flake { };
       in rec {
         apps = {
-          test-ghc8107 = {
+          test-ghc96 = {
             type = "app";
-            program = "${packages.test-ghc8107}/bin/test";
-          };
-          test-ghc902 = {
-            type = "app";
-            program = "${packages.test-ghc902}/bin/test";
+            program = "${packages.test-ghc96}/bin/test";
           };
         };
         packages = {
-          default = flake-ghc8107.packages."hapistrano:exe:hap";
-          test-ghc8107 = flake-ghc8107.packages."hapistrano:test:test".overrideAttrs (_: {
-            postFixup = ''
-              wrapProgram $out/bin/test \
-                --set PATH ${pkgs.lib.makeBinPath [
-                  pkgs.bash
-                  pkgs.coreutils
-                  pkgs.findutils
-                  pkgs.git
-                  pkgs.zsh
-                ]}
-            '';
-          });
-          test-ghc902 = flake-ghc902.packages."hapistrano:test:test".overrideAttrs (_: {
+          default = flake-ghc96.packages."hapistrano:exe:hap";
+          test-ghc96 = flake-ghc96.packages."hapistrano:test:test".overrideAttrs (_: {
             postFixup = ''
               wrapProgram $out/bin/test \
                 --set PATH ${pkgs.lib.makeBinPath [
@@ -85,9 +61,8 @@
           });
         };
         devShells = {
-          default = devShells.ghc902;
-          ghc8107 = flake-ghc8107.devShells.default;
-          ghc902 = flake-ghc902.devShells.default;
+          default = devShells.ghc96;
+          ghc96 = flake-ghc96.devShells.default;
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
           overlays = [
             haskellNix.overlay
             (final: prev: {
-              hapistrano-ghc96 = final.haskell-nix.cabalProject' {
+              hapistrano-ghc966 = final.haskell-nix.cabalProject' {
                 src = final.haskell-nix.haskellLib.cleanGit {
                   name = "hapistrano";
                   src = ./.;
@@ -39,22 +39,22 @@
                   hlint = {};
                   haskell-language-server = {};
                 };
-                compiler-nix-name = "ghc96";
+                compiler-nix-name = "ghc966";
               };
             })
           ];
         };
-        flake-ghc96 = pkgs.hapistrano-ghc96.flake { };
+        flake-ghc966 = pkgs.hapistrano-ghc966.flake { };
       in rec {
         apps = {
-          test-ghc96 = {
+          test-ghc966 = {
             type = "app";
-            program = "${packages.test-ghc96}/bin/test";
+            program = "${packages.test-ghc966}/bin/test";
           };
         };
         packages = {
-          default = flake-ghc96.packages."hapistrano:exe:hap";
-          test-ghc96 = flake-ghc96.packages."hapistrano:test:test".overrideAttrs (_: {
+          default = flake-ghc966.packages."hapistrano:exe:hap";
+          test-ghc966 = flake-ghc966.packages."hapistrano:test:test".overrideAttrs (_: {
             postFixup = ''
               wrapProgram $out/bin/test \
                 --set PATH ${pkgs.lib.makeBinPath [
@@ -68,8 +68,8 @@
           });
         };
         devShells = {
-          default = devShells.ghc96;
-          ghc96 = flake-ghc96.devShells.default;
+          default = devShells.ghc966;
+          ghc966 = flake-ghc966.devShells.default;
         };
       });
 }

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -28,7 +28,7 @@ category:            System
 homepage:            https://github.com/stackbuilders/hapistrano
 bug-reports:         https://github.com/stackbuilders/hapistrano/issues
 build-type:          Simple
-tested-with:         GHC==8.10.17, GHC==9.0.2
+tested-with:         GHC==9.6.5
 extra-doc-files:     CHANGELOG.md
                    , README.md
 

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -66,7 +66,7 @@ library
                      , text               >= 1.2 && < 3
                      , typed-process      >= 0.2 && < 0.3
                      , time               >= 1.5 && < 1.13
-                     , transformers       >= 0.4 && < 0.6
+                     , transformers       >= 0.4 && < 0.7
                      , exceptions         >= 0.10 && < 0.11
                      , yaml               >= 0.11.7 && < 0.12
   if flag(dev)

--- a/hapistrano.cabal
+++ b/hapistrano.cabal
@@ -28,7 +28,7 @@ category:            System
 homepage:            https://github.com/stackbuilders/hapistrano
 bug-reports:         https://github.com/stackbuilders/hapistrano/issues
 build-type:          Simple
-tested-with:         GHC==9.6.5
+tested-with:         GHC==9.6.6
 extra-doc-files:     CHANGELOG.md
                    , README.md
 


### PR DESCRIPTION
This PR simplifies the Nix flake and GHC versions of the flake by removing GHC 8. It also:
- Bumps GHC 9 version from 9.0.2 to 9.6.6 and `transformers` dependency upper bound.
- Changes the GHC-musl image to [the one mentioned here](https://github.com/utdemir/ghc-musl/pull/42#issuecomment-1983312021), since the previous one we were using seems to be unmaintained.
- Adds Cabal, HLint and HLS to the development shell.
- Adds a `.envrc` file for use with `direnv`.
- Updates `flake.lock`.